### PR TITLE
feat: Add workflow for drafting releases

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,0 +1,114 @@
+name: 📜 Release | Draft
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+env:
+  REGISTRY: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distribution:
+          - nr-otel-collector
+          - nrdot-collector-host
+          - nrdot-collector-k8s
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for tag metadata
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          check-latest: true
+
+      - name: Tidy go.mod files
+        run: go mod tidy
+
+      - name: Verify build
+        run: make ci DISTRIBUTIONS=${{ matrix.distribution }}
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        if: ${{ env.ACT }}
+        with:
+          registry: docker.io
+          username: ${{ secrets.OTELCOMM_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.OTELCOMM_DOCKER_HUB_PASSWORD }}
+
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+          passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+
+      - name: Write GPG to path in memory for signing rpm/deb
+        id: write_gpg_to_path
+        run: |
+          GPG_KEY_PATH="$(mktemp /dev/shm/gpg.XXXXXX)"
+          echo "$GPG_PRIVATE_KEY" | base64 -d >> "$GPG_KEY_PATH"
+          echo "gpg_key_path=$GPG_KEY_PATH" >> $GITHUB_OUTPUT
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OTELCOMM_AWS_TEST_ACC_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}:role/resource-provisioner
+          role-skip-session-tagging: true
+
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY}}/${{ matrix.distribution }}
+
+      - name: Build binaries & packages with GoReleaser
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          NFPM_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_KEY_PATH: ${{ steps.write_gpg_to_path.outputs.gpg_key_path }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: --clean --skip=announce --timeout 2h
+          workdir: distributions/${{ matrix.distribution }}
+
+  draft-release:
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.23'
+
+      - name: Draft Release From Root Config
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: --clean --timeout 2h
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         distribution:
-          - nr-otel-collector
           - nrdot-collector-host
           - nrdot-collector-k8s
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,7 @@
+version: 2
+builds:
+  - skip: true
+release:
+  draft: true
+  use_existing_draft: true
+  mode: replace

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -31,7 +31,6 @@ const (
 	HostDistro = "nrdot-collector-host"
 	K8sDistro  = "nrdot-collector-k8s"
 
-	DockerHub   = "newrelic"
 	EnvRegistry = "{{ .Env.REGISTRY }}"
 
 	BinaryNamePrefix = "nrdot-collector"
@@ -39,10 +38,9 @@ const (
 )
 
 var (
-	ImagePrefixes        = []string{DockerHub}
-	NightlyImagePrefixes = []string{EnvRegistry}
-	Architectures        = []string{"amd64", "arm64"}
-	SkipBinaries         = map[string]bool{
+	ImagePrefixes = []string{EnvRegistry}
+	Architectures = []string{"amd64", "arm64"}
+	SkipBinaries  = map[string]bool{
 		K8sDistro: true,
 	}
 	NfpmDefaultConfig = map[string]string{
@@ -61,9 +59,11 @@ var (
 func Generate(dist string, nightly bool) config.Project {
 
 	projectName := "nrdot-collector-releases"
+	disableRelease := "false"
 
 	if nightly {
 		projectName = "nrdot-collector-releases-nightly"
+		disableRelease = "true"
 	}
 
 	return config.Project{
@@ -86,8 +86,8 @@ func Generate(dist string, nightly bool) config.Project {
 		},
 		Blobs: Blobs(dist, nightly),
 		Release: config.Release{
-			// Disable releases on all distros for now
-			Disable: "true",
+			Disable: disableRelease,
+			Draft:   true,
 		},
 	}
 }
@@ -286,7 +286,6 @@ func DockerImage(dist string, nightly bool, arch string, armVersion string) conf
 	latestPrefixFormat := "%s/%s:latest-%s"
 
 	if nightly {
-		imagePrefixes = NightlyImagePrefixes
 		prefixFormat = "%s/%s:{{ .Version }}-nightly-%s"
 		latestPrefixFormat = "%s/%s:nightly-%s"
 	}
@@ -335,10 +334,6 @@ func DockerManifests(dist string, nightly bool) []config.DockerManifest {
 	r := make([]config.DockerManifest, 0)
 
 	imagePrefixes := ImagePrefixes
-
-	if nightly {
-		imagePrefixes = NightlyImagePrefixes
-	}
 
 	for _, prefix := range imagePrefixes {
 		if nightly {

--- a/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
@@ -1,6 +1,7 @@
 version: 2
 project_name: nrdot-collector-releases-nightly
 release:
+  draft: true
   disable: "true"
 builds:
   - id: nrdot-collector-host

--- a/distributions/nrdot-collector-host/.goreleaser.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser.yaml
@@ -1,7 +1,8 @@
 version: 2
 project_name: nrdot-collector-releases
 release:
-  disable: "true"
+  draft: true
+  disable: "false"
 builds:
   - id: nrdot-collector-host
     goos:
@@ -77,8 +78,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - newrelic/nrdot-collector-host:{{ .Version }}-amd64
-      - newrelic/nrdot-collector-host:latest-amd64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:latest-amd64'
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -95,8 +96,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - newrelic/nrdot-collector-host:{{ .Version }}-arm64
-      - newrelic/nrdot-collector-host:latest-arm64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-arm64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:latest-arm64'
     extra_files:
       - config.yaml
     build_flag_templates:
@@ -110,14 +111,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: newrelic/nrdot-collector-host:{{ .Version }}
+  - name_template: '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}'
     image_templates:
-      - newrelic/nrdot-collector-host:{{ .Version }}-amd64
-      - newrelic/nrdot-collector-host:{{ .Version }}-arm64
-  - name_template: newrelic/nrdot-collector-host:latest
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-arm64'
+  - name_template: '{{ .Env.REGISTRY }}/nrdot-collector-host:latest'
     image_templates:
-      - newrelic/nrdot-collector-host:latest-amd64
-      - newrelic/nrdot-collector-host:latest-arm64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:latest-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:latest-arm64'
 blobs:
   - bucket: nr-releases
     provider: s3

--- a/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
@@ -1,6 +1,7 @@
 version: 2
 project_name: nrdot-collector-releases-nightly
 release:
+  draft: true
   disable: "true"
 builds:
   - id: nrdot-collector-k8s

--- a/distributions/nrdot-collector-k8s/.goreleaser.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser.yaml
@@ -1,7 +1,8 @@
 version: 2
 project_name: nrdot-collector-releases
 release:
-  disable: "true"
+  draft: true
+  disable: "false"
 builds:
   - id: nrdot-collector-k8s
     goos:
@@ -29,8 +30,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - newrelic/nrdot-collector-k8s:{{ .Version }}-amd64
-      - newrelic/nrdot-collector-k8s:latest-amd64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:{{ .Version }}-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:latest-amd64'
     extra_files:
       - config-daemonset.yaml
       - config-deployment.yaml
@@ -48,8 +49,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     image_templates:
-      - newrelic/nrdot-collector-k8s:{{ .Version }}-arm64
-      - newrelic/nrdot-collector-k8s:latest-arm64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:{{ .Version }}-arm64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:latest-arm64'
     extra_files:
       - config-daemonset.yaml
       - config-deployment.yaml
@@ -64,14 +65,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
     use: buildx
 docker_manifests:
-  - name_template: newrelic/nrdot-collector-k8s:{{ .Version }}
+  - name_template: '{{ .Env.REGISTRY }}/nrdot-collector-k8s:{{ .Version }}'
     image_templates:
-      - newrelic/nrdot-collector-k8s:{{ .Version }}-amd64
-      - newrelic/nrdot-collector-k8s:{{ .Version }}-arm64
-  - name_template: newrelic/nrdot-collector-k8s:latest
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:{{ .Version }}-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:{{ .Version }}-arm64'
+  - name_template: '{{ .Env.REGISTRY }}/nrdot-collector-k8s:latest'
     image_templates:
-      - newrelic/nrdot-collector-k8s:latest-amd64
-      - newrelic/nrdot-collector-k8s:latest-arm64
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:latest-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-k8s:latest-arm64'
 changelog:
   disable: "true"
 signs:


### PR DESCRIPTION
Adds a new workflow to generate a draft release on tag push.

1. Build and publish each distro via their respective .goreleaser.yaml configs.  They will publish docker images to ECR for now and append or create a new draft release in GH as well as upload all of their generated artifacts.
2. Run goreleaser on the root config which will populate the draft with the changes included since last release.

A followup PR is going to be required to handle the publishing of the release, this will also need to push and tag images to docker hub.

