### PR TITLE
fix: relax condition on steal metric

### DIFF
--- a/test/e2e/util/spec/on_host.go
+++ b/test/e2e/util/spec/on_host.go
@@ -42,7 +42,7 @@ var testCases = []TestCase{
 			Name:        "system.cpu.utilization",
 			WhereClause: "WHERE state='steal'"},
 		Assertions: []assert.NrAssertion{
-			{AggregationFunction: "max", ComparisonOperator: ">", Threshold: 0},
+			{AggregationFunction: "max", ComparisonOperator: ">=", Threshold: 0},
 		}},
 	{
 		Name: "host receiver disk.io read",


### PR DESCRIPTION
### Summary
- Nightly [fails](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13401218903/job/37432282013#step:17:92) due to new requirement of cpu util for `state=steal` but it's [just 0](https://onenr.io/0PwJ943M5Q7) which is fine as far as I understand the metric
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/58d85937-0677-4292-b2bf-ad6ec4f98039" />
