### PR TITLE
feat: provide env var defaults for docker

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -128,7 +128,7 @@ jobs:
             yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')" >> $GITHUB_OUTPUT
     outputs:
       docker_manifest_sha: ${{ steps.extract_docker_manifest_sha.outputs.docker_manifest_sha }}
-  
+
   deploy-nightly:
     name: Deploy Nightly
     uses: ./.github/workflows/terraform.yaml

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -23,5 +23,5 @@ The default configuration exposes some options via environment variables:
 |---|---|---|
 | `NEW_RELIC_LICENSE_KEY` | New Relic ingest key | N/A - Required |
 | `NEW_RELIC_MEMORY_LIMIT_MIB` | Maximum amount of memory to be used | 100 |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | New Relic OTLP endpoint to export metrics to, see [official docs](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) | `https://otlp.nr-data.net:4317` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | New Relic OTLP endpoint to export metrics to, see [official docs](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) | `https://otlp.nr-data.net` |
 

--- a/distributions/nrdot-collector-host/config.yaml
+++ b/distributions/nrdot-collector-host/config.yaml
@@ -165,7 +165,7 @@ processors:
   # used to prevent out of memory situations on the collector
   memory_limiter:
     check_interval: 1s
-    limit_mib: ${NEW_RELIC_MEMORY_LIMIT_MIB}
+    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB:-100}
 
   batch:
 
@@ -195,9 +195,9 @@ processors:
 exporters:
   debug:
   otlphttp:
-    endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT:-https://otlp.nr-data.net}
     headers:
-      api-key: ${NEW_RELIC_LICENSE_KEY}
+      api-key: ${env:NEW_RELIC_LICENSE_KEY}
 
 service:
   pipelines:

--- a/distributions/nrdot-collector-host/nrdot-collector-host.conf
+++ b/distributions/nrdot-collector-host/nrdot-collector-host.conf
@@ -1,12 +1,4 @@
 # Systemd environment file for the nrdot-collector-host service
-
-# New Relic default variables
-OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net:4317
-NEW_RELIC_MEMORY_LIMIT_MIB=100
-
 # Command-line options for the nrdot-collector-host service.
-# Run `/usr/bin/nrdot-collector-host --help` to see all available options.
-#
-# pkg.translator.prometheus.NormalizeName feature-gate is disabled by default to avoid altering prometheus metrics
-# names when reported through non-prometheus exporters.
+# See https://opentelemetry.io/docs/collector/configuration/ to see all available options.
 OTELCOL_OPTIONS="--config=/etc/nrdot-collector-host/config.yaml"


### PR DESCRIPTION
### Summary
- Supply env var defaults via config instead of systemd config to also provide defaults when used as docker image
- Dropped the port for simplicity as 443 supports both gRPC and http, see [NR docs](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/#note-ports). As far as I can tell, the old systemd default port was also wrong as it was for gRPC while the config used the otlphttpexporter