### PR TITLE
fix: namespace kind clusters used for slow tests

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -26,7 +26,7 @@ jobs:
     with:
       nightly: true
       distribution: ${{ matrix.distribution }}
-      test_cluster_name: 'ci-e2etest-nightly'
+      test_cluster_name: 'ci-e2etest-nightly-${{ matrix.distribution }}'
     secrets:
       docker_hub_username: ${{ secrets.OTELCOMM_DOCKER_HUB_USERNAME }}
       docker_hub_password: ${{ secrets.OTELCOMM_DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
### Summary
- Namespacing clusters used for nightly slow tests to avoid interference between tests of different distros