### PR TITLE
fix: override namespace of clusterrole

### DIFF
--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -27,7 +27,7 @@ func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsSlowTest(t)
 	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
 	testId := testutil.NewTestId()
-	testChart = chart.NewNrBackendChart(testId)
+	testChart = chart.NewNrBackendChart(testId, kubectlOptions.Namespace)
 
 	t.Logf("hostname used for test: %s", testChart.NrQueryHostNamePattern)
 	helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)

--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -11,9 +11,10 @@ import (
 type NrBackendChart struct {
 	collectorHostNamePrefix string
 	NrQueryHostNamePattern  string
+	namespace               string
 }
 
-func NewNrBackendChart(testId string) NrBackendChart {
+func NewNrBackendChart(testId string, namespace string) NrBackendChart {
 	var environmentName string
 	if envutil.IsContinuousIntegration() {
 		environmentName = "ci"
@@ -30,6 +31,7 @@ func NewNrBackendChart(testId string) NrBackendChart {
 	return NrBackendChart{
 		collectorHostNamePrefix: hostNamePrefix,
 		NrQueryHostNamePattern:  hostNamePattern,
+		namespace:               namespace,
 	}
 }
 
@@ -51,5 +53,6 @@ func (m *NrBackendChart) RequiredChartValues() map[string]string {
 		"secrets.nrBackendUrl": envutil.GetNrBackendUrl(),
 		"secrets.nrIngestKey":  envutil.GetNrIngestKey(),
 		"collector.hostname":   m.collectorHostNamePrefix,
+		"namespace":            m.namespace,
 	}
 }


### PR DESCRIPTION
### Summary
- the slow test didn't supply a namespace value, leaving the ClusterRole with the (wrong) default namespace name, leading to [permissions issues for nightly](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13403283329/job/37438427097#step:17:444)