### PR TITLE
feat: Add release tag helper and version validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO_LICENCE_DETECTOR_CONFIG   := $(SRC_ROOT)/internal/assets/license/rules.json
 
 DISTRIBUTIONS ?= "nrdot-collector-host,nrdot-collector-k8s"
 
-ci: check build licenses-check
+ci: check build version-check licenses-check
 check: ensure-goreleaser-up-to-date
 
 build: go ocb
@@ -77,6 +77,22 @@ goreleaser:
 			exit 1; \
 		fi \
 	}
+
+VERSION := $(shell ./scripts/get-version.sh)
+
+.PHONY: version-check
+version-check:
+	@echo $(VERSION)
+
+REMOTE?=git@github.com:newrelic/nrdot-collector-releases.git
+.PHONY: push-release-tag
+push-release-tag:
+	@[ "${VERSION}" ] || ( echo ">> VERSION is not set"; exit 1 )
+	@echo "Adding tag ${VERSION}"
+	@git tag -a ${VERSION} -s -m "Version ${VERSION}"
+	@read -p "Are you sure you want to push the tag ${VERSION} to ${REMOTE}? (y/N) " confirm && [ $${confirm} = y ]
+	@echo "Pushing tag ${VERSION}"
+	@git push ${REMOTE} ${VERSION}
 
 .PHONY: install-tools
 install-tools: $(TOOLS_BIN_NAMES)

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script validates that all manifest.yaml files in the distributions directory have the same version number.
+# If they do, it prints the version number to stdout and exits with status 0.
+# If they don't, it prints an error message to stderr and exits with status 1.
+
+set -e
+
+version=""
+
+for manifest in ./distributions/*/manifest.yaml; do
+  if [ -f "$manifest" ]; then
+    current_version=$(grep -E '^  version:' "$manifest" | awk '{print $2}')
+    if [ -z "$version" ]; then
+      version="$current_version"
+    elif [ "$version" != "$current_version" ]; then
+      echo "Version mismatch detected in $manifest"
+      exit 1
+    fi
+  fi
+done
+
+if [ -z "$version" ]; then
+  echo "No version found in any manifest.yaml"
+  exit 1
+fi
+
+echo $version


### PR DESCRIPTION
Adding a helper target for generating new release tag along with basic version validation across the distros.