### PR TITLE
fix: retry NR backend validations

### DIFF
--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -55,7 +55,7 @@ func TestNightlyHostMetrics(t *testing.T) {
 				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 				// space out requests to avoid rate limiting
 				time.Sleep(time.Duration(i) * requestSpacing)
-				assertion.Execute(t, client)
+				assertion.ExecuteWithRetries(t, client, 15, 5*time.Second)
 			})
 		}
 	}

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -49,7 +49,7 @@ func TestStartupBehavior(t *testing.T) {
 			assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 			// space out requests to avoid rate limiting
 			time.Sleep(time.Duration(i) * requestSpacing)
-			assertion.Execute(t, client)
+			assertion.ExecuteWithRetries(t, client, 15, 5*time.Second)
 		})
 	}
 }


### PR DESCRIPTION
### Summary
- Nightly run [failed due to missing metric](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13419200827/job/37487529735#step:17:105) but metric [did get ingested](https://onenr.io/02wdo549GQE), so I assume it's a race condition. Adding some retry behavior to not immediately fail but account for variable ingest delay