### PR TITLE
fix: avoid use of index when reading ecr

### DIFF
--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -23,7 +23,7 @@ resource "helm_release" "ci_e2e_nightly" {
 
   set {
     name  = "image.repository"
-    value = data.aws_ecr_repository.ecr_repo[var.distro].repository_url
+    value = data.aws_ecr_repository.ecr_repo.repository_url
   }
 
   set {


### PR DESCRIPTION
### Summary
- fix [remnant](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13419200827/job/37493600871#step:6:102) of refactoring that happened during #218 - tf used to handle all distros instead of namespacing it via workspaces. ecr data construct now uniquely identifies a distro's repo, so no need for indexing.