### PR TITLE
chore: Updating otel components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORELEASER ?= goreleaser
 
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
-OTELCOL_BUILDER_VERSION ?= 0.119.0
+OTELCOL_BUILDER_VERSION ?= 0.120.0
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -6,34 +6,34 @@ dist:
   output_path: ./_build
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.119.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.120.1
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.120.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.119.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.119.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.120.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.120.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.120.1
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.119.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.119.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.119.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.120.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.25.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.26.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -6,41 +6,41 @@ dist:
   output_path: ./_build
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.119.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.120.1
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.120.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.119.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.119.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.119.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.120.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.120.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.120.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.120.1
 
 exporters:
   # shared
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.119.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.119.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.119.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.120.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.25.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.25.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.26.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.26.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+
+# Function to validate semantic version and strip leading 'v'
+validate_and_strip_version() {
+  local var_name=$1
+  local version=${!var_name}
+  # Strip leading 'v' if present
+  version=${version#v}
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid version: $version. Must be a semantic version (e.g., 1.2.3)."
+    exit 1
+  fi
+  eval "$var_name='$version'"
+}
+
+
+# Get the most recent release tag from the open-telemetry/opentelemetry-collector-contrib repo
+get_latest_otel_release_tag() {
+    local repo="open-telemetry/opentelemetry-collector-releases"
+    local latest_tag=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | jq -r .tag_name)
+    if [[ -z $latest_tag ]]; then
+        echo "Failed to fetch the latest release tag from $repo."
+        exit 1
+    fi
+    
+    validate_and_strip_version latest_tag
+    echo "$latest_tag"
+}
+
+
+otel_version=$(get_latest_otel_release_tag)
+manifest_url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v${otel_version}/distributions/otelcol/manifest.yaml"
+manifest_content=$(curl --silent "$manifest_url")
+
+# Extract the distribution version from the manifest content
+next_beta_core=$(echo "$manifest_content" | awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}')
+next_beta_contrib=$(echo "$manifest_content" | awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}')
+next_stable=$(echo "$manifest_content" | awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}')
+
+validate_and_strip_version next_beta_core
+validate_and_strip_version next_beta_contrib
+validate_and_strip_version next_stable
+
+echo "Next beta core version: $next_beta_core"
+echo "Next beta contrib version: $next_beta_contrib"
+echo "Next stable version: $next_stable"
+
+# Get the current versions from the manifest.yaml files
+current_beta_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
+current_beta_contrib=$(awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
+current_stable=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
+
+validate_and_strip_version current_beta_core
+validate_and_strip_version current_beta_contrib
+validate_and_strip_version current_stable
+
+echo "Current beta core version: $current_beta_core"
+echo "Current beta contrib version: $current_beta_contrib"
+echo "Current stable version: $current_stable"
+
+
+# add escape characters to the current versions to work with sed
+escaped_current_beta_core=${current_beta_core//./\\.}
+escaped_current_beta_contrib=${current_beta_contrib//./\\.}
+escaped_current_stable=${current_stable//./\\.}
+
+# Determine the OS and set the sed command accordingly
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  sed_command="sed -i ''"
+else
+  # Linux
+  sed_command="sed -i"
+fi
+
+# Update versions in each manifest file
+echo "Updating core beta version from $current_beta_core to $next_beta_core,"
+echo "core stable version from $current_stable to $next_stable,"
+echo "contrib beta version from $current_beta_contrib to $next_beta_contrib,"
+echo "and distribution version to $next_distribution_version"
+for file in ./distributions/*/manifest.yaml; do
+  if [ -f "$file" ]; then
+    $sed_command "s/\(^.*go\.opentelemetry\.io\/collector\/.*\) v$escaped_current_beta_core/\1 v$next_beta_core/" "$file"
+    $sed_command "s/\(^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.*\) v$escaped_current_beta_contrib/\1 v$next_beta_contrib/" "$file"
+    $sed_command "s/\(^.*go\.opentelemetry\.io\/collector\/.*\) v$escaped_current_stable/\1 v$next_stable/" "$file"
+  else
+    echo "File $file does not exist"
+  fi
+done
+
+# Update Makefile OCB version
+$sed_command "s/OTELCOL_BUILDER_VERSION ?= $escaped_current_beta_core/OTELCOL_BUILDER_VERSION ?= $next_beta_core/" Makefile


### PR DESCRIPTION
Added a helper script until we configure rennovate to ensure we're using the correct versions of contrib/core as well as updated our components to 1.20.0