### PR TITLE
fix: namespace cluster roles for multi chart install

### DIFF
--- a/test/charts/mocked_backend/templates/k8s-api-access.yaml
+++ b/test/charts/mocked_backend/templates/k8s-api-access.yaml
@@ -6,7 +6,8 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-k8s-api-role
+  # namespace suffix to avoid conflicts when installing chart multiple times
+  name: read-k8s-api-role-{{ .Values.namespace }}
 # required rules copied from:
 # - k8seventsreceiever: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8seventsreceiver/README.md#rbac
 rules:

--- a/test/charts/nr_backend/templates/k8s-api-access.yaml
+++ b/test/charts/nr_backend/templates/k8s-api-access.yaml
@@ -6,7 +6,8 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-k8s-api-role
+  # namespace suffix to avoid conflicts when installing chart multiple times
+  name: read-k8s-api-role-{{ .Values.namespace }}
 # required rules copied from:
 # - k8seventsreceiever: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8seventsreceiver/README.md#rbac
 rules:


### PR DESCRIPTION
### Summary
- tf nightly apply failed due to the [non-namespaced](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/) `ClusterRole` running into conflicts.
- Adding `meta.namespace` wouldn't have helped if I understand [the docs](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta) correctly as `ClusterRole` falls into
> Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.