### PR TITLE
fix: Issue with race condition while publishing draft

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -9,8 +9,30 @@ env:
   REGISTRY: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
 
 jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.23'
+
+      - name: Draft Release From Root Config
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: --clean --timeout 2h
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-artifacts:
     runs-on: ubuntu-latest
+    needs: draft-release
     strategy:
       matrix:
         distribution:
@@ -89,25 +111,3 @@ jobs:
           version: '~> v2'
           args: --clean --skip=announce --timeout 2h
           workdir: distributions/${{ matrix.distribution }}
-
-  draft-release:
-    runs-on: ubuntu-latest
-    needs: build-artifacts
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.23'
-
-      - name: Draft Release From Root Config
-        id: goreleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: '~> v2'
-          args: --clean --timeout 2h
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -86,8 +86,10 @@ func Generate(dist string, nightly bool) config.Project {
 		},
 		Blobs: Blobs(dist, nightly),
 		Release: config.Release{
-			Disable: disableRelease,
-			Draft:   true,
+			Disable:              disableRelease,
+			Draft:                true,
+			UseExistingDraft:     true,
+			ReplaceExistingDraft: false,
 		},
 	}
 }

--- a/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
@@ -2,6 +2,7 @@ version: 2
 project_name: nrdot-collector-releases-nightly
 release:
   draft: true
+  use_existing_draft: true
   disable: "true"
 builds:
   - id: nrdot-collector-host

--- a/distributions/nrdot-collector-host/.goreleaser.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser.yaml
@@ -2,6 +2,7 @@ version: 2
 project_name: nrdot-collector-releases
 release:
   draft: true
+  use_existing_draft: true
   disable: "false"
 builds:
   - id: nrdot-collector-host

--- a/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
@@ -2,6 +2,7 @@ version: 2
 project_name: nrdot-collector-releases-nightly
 release:
   draft: true
+  use_existing_draft: true
   disable: "true"
 builds:
   - id: nrdot-collector-k8s

--- a/distributions/nrdot-collector-k8s/.goreleaser.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser.yaml
@@ -2,6 +2,7 @@ version: 2
 project_name: nrdot-collector-releases
 release:
   draft: true
+  use_existing_draft: true
   disable: "false"
 builds:
   - id: nrdot-collector-k8s


### PR DESCRIPTION
Looks like the parallel builds can create a race condition when attempting to post the draft, moving things around to ensure the draft is already present when they start.