### PR TITLE
fix: Add archive option to k8s distro

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -163,9 +163,6 @@ func ArmVersions(dist string) []string {
 }
 
 func Archives(dist string) []config.Archive {
-	if skip, ok := SkipBinaries[dist]; ok && skip {
-		return nil
-	}
 	return []config.Archive{
 		Archive(dist),
 	}

--- a/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser-nightly.yaml
@@ -20,6 +20,15 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=0
+archives:
+  - id: nrdot-collector-k8s
+    builds:
+      - nrdot-collector-k8s
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 snapshot:
   version_template: '{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}'
 checksum:

--- a/distributions/nrdot-collector-k8s/.goreleaser.yaml
+++ b/distributions/nrdot-collector-k8s/.goreleaser.yaml
@@ -20,6 +20,15 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=0
+archives:
+  - id: nrdot-collector-k8s
+    builds:
+      - nrdot-collector-k8s
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 snapshot:
   version_template: '{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}'
 checksum:


### PR DESCRIPTION
By default it looks like the binaries are built into an archive file so in order to ensure the name matches the distro we need to keep the config: https://goreleaser.com/customization/archive/?h=archives#archives

