### PR TITLE
ci: use correct repo and tf project name for state

### DIFF
--- a/test/terraform/nightly/providers.tf
+++ b/test/terraform/nightly/providers.tf
@@ -15,7 +15,7 @@ terraform {
     encrypt        = true
     dynamodb_table = "terraform-states-lock"
     region         = "us-east-1"
-    key            = "newrelic/opentelemetry-collector-releases/permanent/terraform.tfstate"
+    key            = "newrelic/nrdot-collector-releases/nightly/terraform.tfstate"
     # 'bucket' and 'role_arn' provided via '-backend-config'
   }
 }


### PR DESCRIPTION
### Summary
- State name now uses the new repo name and the correct folder name for namespacing