### PR TITLE
fix: provide namespace for clusterrole in nightly

### DIFF
--- a/test/charts/mocked_backend/templates/k8s-api-access.yaml
+++ b/test/charts/mocked_backend/templates/k8s-api-access.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-k8s-api-role-{{ .Values.namespace }}
+  name: read-k8s-api-role-{{ .Release.Namespace }}
 # required rules copied from:
 # - k8seventsreceiever: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8seventsreceiver/README.md#rbac
 rules:
@@ -78,12 +78,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: read-k8s-api-binding-{{ .Values.namespace }}
+  name: read-k8s-api-binding-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: read-k8s-api-role-{{ .Values.namespace }}
+  name: read-k8s-api-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: read-k8s-api-account
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/test/charts/mocked_backend/values.yaml
+++ b/test/charts/mocked_backend/values.yaml
@@ -3,5 +3,3 @@ image:
   tag: latest
   # Avoid accidentally pulling remote images in CI
   pullPolicy: Never
-
-namespace: default-mocked-backend

--- a/test/charts/nr_backend/templates/k8s-api-access.yaml
+++ b/test/charts/nr_backend/templates/k8s-api-access.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-k8s-api-role-{{ .Values.namespace }}
+  name: read-k8s-api-role-{{ .Release.Namespace }}
 # required rules copied from:
 # - k8seventsreceiever: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8seventsreceiver/README.md#rbac
 rules:
@@ -78,12 +78,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: read-k8s-api-binding-{{ .Values.namespace }}
+  name: read-k8s-api-binding-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: read-k8s-api-role-{{ .Values.namespace }}
+  name: read-k8s-api-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: read-k8s-api-account
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/test/charts/nr_backend/values.yaml
+++ b/test/charts/nr_backend/values.yaml
@@ -10,5 +10,3 @@ secrets:
 
 collector:
   hostname: nrdot-collector-default-hostname
-
-namespace: default-nr-backend

--- a/test/e2e/hostmetrics/hostmetrics_test.go
+++ b/test/e2e/hostmetrics/hostmetrics_test.go
@@ -34,7 +34,7 @@ type ValidationPayload struct {
 func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsFastTest(t)
 	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
-	testChart = chart.NewMockedBackendChart(kubectlOptions.Namespace)
+	testChart = chart.NewMockedBackendChart()
 	testId = testutil.NewTestId()
 	helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)
 

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -27,7 +27,7 @@ func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsSlowTest(t)
 	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
 	testId := testutil.NewTestId()
-	testChart = chart.NewNrBackendChart(testId, kubectlOptions.Namespace)
+	testChart = chart.NewNrBackendChart(testId)
 
 	t.Logf("hostname used for test: %s", testChart.NrQueryHostNamePattern)
 	helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)

--- a/test/e2e/util/chart/mocked_backend.go
+++ b/test/e2e/util/chart/mocked_backend.go
@@ -6,13 +6,10 @@ import (
 )
 
 type MockedBackendChart struct {
-	namespace string
 }
 
-func NewMockedBackendChart(namespace string) MockedBackendChart {
-	return MockedBackendChart{
-		namespace: namespace,
-	}
+func NewMockedBackendChart() MockedBackendChart {
+	return MockedBackendChart{}
 }
 
 func (m *MockedBackendChart) AsChart() Chart {
@@ -30,6 +27,5 @@ func (m *MockedBackendChart) RequiredChartValues() map[string]string {
 	return map[string]string{
 		"image.repository": fmt.Sprintf("newrelic/%s", envutil.GetDistro()),
 		"image.tag":        envutil.GetImageTag(),
-		"namespace":        m.namespace,
 	}
 }

--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -14,7 +14,7 @@ type NrBackendChart struct {
 	namespace               string
 }
 
-func NewNrBackendChart(testId string, namespace string) NrBackendChart {
+func NewNrBackendChart(testId string) NrBackendChart {
 	var environmentName string
 	if envutil.IsContinuousIntegration() {
 		environmentName = "ci"
@@ -31,7 +31,6 @@ func NewNrBackendChart(testId string, namespace string) NrBackendChart {
 	return NrBackendChart{
 		collectorHostNamePrefix: hostNamePrefix,
 		NrQueryHostNamePattern:  hostNamePattern,
-		namespace:               namespace,
 	}
 }
 
@@ -53,6 +52,5 @@ func (m *NrBackendChart) RequiredChartValues() map[string]string {
 		"secrets.nrBackendUrl": envutil.GetNrBackendUrl(),
 		"secrets.nrIngestKey":  envutil.GetNrIngestKey(),
 		"collector.hostname":   m.collectorHostNamePrefix,
-		"namespace":            m.namespace,
 	}
 }

--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -2,6 +2,7 @@ locals {
   test_spec                                       = yamldecode(file("${path.module}/../../../distributions/${var.distro}/test-spec.yaml"))
   releases_bucket_name                            = "nr-releases"
   required_permissions_boundary_arn_for_new_roles = "arn:aws:iam::${var.aws_account_id}:policy/resource-provisioner-boundary"
+  k8s_namespace = "nightly-${var.distro}"
 }
 
 resource "random_string" "deploy_id" {
@@ -19,7 +20,7 @@ resource "helm_release" "ci_e2e_nightly" {
   chart = "../../charts/nr_backend"
 
   create_namespace = true
-  namespace        = "nightly-${var.distro}"
+  namespace        = local.k8s_namespace
 
   set {
     name  = "image.repository"


### PR DESCRIPTION
### Summary
- `namespace` value is missing from nightly helm chart