### PR TITLE
ci: limit concurrency of nightly tf

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -139,6 +139,9 @@ jobs:
         distribution:
           - nrdot-collector-host
           - nrdot-collector-k8s
+    concurrency:
+      # concurrency limit of 1 b/c failed tf job cancelling each other causes tf state and locks to corrupt
+      group: deploy-nightly-terraform
     with:
       branch: ${{ github.ref }}
       tf_work_subdir: nightly


### PR DESCRIPTION
### Summary
- Having nightly apply the tf for each distro concurrently causes deadlocks in dynamoDB and state corruption when one tf fails and kills the other one.
- Following [github docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior) using concurrency groups to limit concurrency to 1