### PR TITLE
ci: add label to goreleaser publish step

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -109,6 +109,7 @@ jobs:
           registry: ${{ env.REGISTRY}}/${{ matrix.distribution }}
 
       - name: Build and publish ${{ matrix.distribution }} nightly binaries & packages with GoReleaser
+        id: goreleaser_publish
         if: ${{ !env.ACT }}
         uses: goreleaser/goreleaser-action@v6
         env:
@@ -124,7 +125,7 @@ jobs:
       - name: Extract Docker Manifest SHA
         id: extract_docker_manifest_sha
         run: |
-          echo "docker_manifest_sha=$(echo '${{ steps.goreleaser.outputs.artifacts }}' |
+          echo "docker_manifest_sha=$(echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
             yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')" >> $GITHUB_OUTPUT
     outputs:
       docker_manifest_sha: ${{ steps.extract_docker_manifest_sha.outputs.docker_manifest_sha }}


### PR DESCRIPTION
### Summary
- goreleaser nightly publish step was missing an `id` to extract the artifacts