### PR TITLE
ci: correctly pass docker manifest sha to tf

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -2,3 +2,4 @@
 --container-architecture=linux/arm64
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
 -e event.json
+--artifact-server-path $PWD/.artifacts

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -125,10 +125,13 @@ jobs:
       - name: Extract Docker Manifest SHA
         id: extract_docker_manifest_sha
         run: |
-          echo "docker_manifest_sha=$(echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
-            yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')" >> $GITHUB_OUTPUT
-    outputs:
-      docker_manifest_sha: ${{ steps.extract_docker_manifest_sha.outputs.docker_manifest_sha }}
+          echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
+            yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')" > docker_manifest_sha
+      - name: Upload math result for job 1
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker_manifest_sha_${{ matrix.distribution }}
+          path: docker_manifest_sha
 
   deploy-nightly:
     name: Deploy Nightly
@@ -150,7 +153,7 @@ jobs:
       execute_plan: true
       execute_apply: true
       distro: ${{ matrix.distribution }}
-      nightly_docker_manifest_sha: ${{ needs.publish.outputs.docker_manifest_sha }}
+      nightly_docker_manifest_sha_artifact_name: docker_manifest_sha_${{ matrix.distribution }}
     secrets:
       aws_access_key_id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{secrets.OTELCOMM_AWS_TEST_ACC_SECRET_ACCESS_KEY}}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -123,11 +123,12 @@ jobs:
           args: --skip=announce,validate --clean --timeout 2h --config .goreleaser-nightly.yaml
           workdir: distributions/${{ matrix.distribution }}
       - name: Extract Docker Manifest SHA
-        id: extract_docker_manifest_sha
-        run: |
-          echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
-            yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')" > docker_manifest_sha
-      - name: Upload math result for job 1
+        run: | 
+          docker_manifest_sha=$(echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
+            yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')
+          echo "docker manifest sha: ${docker_manifest_sha}"
+          echo -n "${docker_manifest_sha}" > docker_manifest_sha
+      - name: Upload Docker Manifest SHA
         uses: actions/upload-artifact@v4
         with:
           name: docker_manifest_sha_${{ matrix.distribution }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -127,12 +127,12 @@ jobs:
           docker_manifest_sha=$(echo '${{ steps.goreleaser_publish.outputs.artifacts }}' |
             yq -r '.[] | select(.type == "Docker Manifest") | .extra.Digest')
           echo "docker manifest sha: ${docker_manifest_sha}"
-          echo -n "${docker_manifest_sha}" > docker_manifest_sha
+          echo -n "${docker_manifest_sha}" > docker_manifest_sha_${{ matrix.distribution }}
       - name: Upload Docker Manifest SHA
         uses: actions/upload-artifact@v4
         with:
           name: docker_manifest_sha_${{ matrix.distribution }}
-          path: docker_manifest_sha
+          path: docker_manifest_sha_${{ matrix.distribution }}
 
   deploy-nightly:
     name: Deploy Nightly

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -172,6 +172,9 @@ jobs:
           - nrdot-collector-host
           - nrdot-collector-k8s
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run nightly tests for ${{ matrix.distribution }}
         run: |
           NR_API_KEY=${{ secrets.OTELCOMM_NR_API_KEY }} \

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -175,6 +175,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          check-latest: true
+
       - name: Run nightly tests for ${{ matrix.distribution }}
         run: |
           NR_API_KEY=${{ secrets.OTELCOMM_NR_API_KEY }} \

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -97,6 +97,7 @@ jobs:
       - name: Terraform Plan
         if: ${{ inputs.nightly_docker_manifest_sha_artifact_name != '' }}
         run: |
+          echo "using docker manifest sha: $(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})"
           echo "TF_VAR_nightly_docker_manifest_sha=$(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})" >> $GITHUB_ENV
 
       - name: Setup Terraform

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -46,11 +46,11 @@ on:
         type: string
         required: false
         default: "nrdot-collector-host"
-      nightly_docker_manifest_sha:
-        description: "SHA256 to identify nightly docker manifest to use"
+      nightly_docker_manifest_sha_artifact_name:
+        description: "artifact name containing SHA256 to identify nightly docker manifest to use"
         type: string
         required: false
-        default: "docker_manifest_sha_placeholder"
+        default: ""
     secrets:
       aws_access_key_id:
         description: "AWS credentials for tf with permission to assume resource-provider"
@@ -81,13 +81,23 @@ jobs:
       TF_VAR_nr_backend_url: ${{ secrets.nr_backend_url }}
       TF_VAR_nr_ingest_key: ${{ secrets.nr_ingest_key }}
       TF_VAR_distro: ${{ inputs.distro }}
-      TF_VAR_nightly_docker_manifest_sha: ${{ inputs.nightly_docker_manifest_sha }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+
+      - name: Download artifact for docker manifest sha
+        if: ${{ inputs.nightly_docker_manifest_sha_artifact_name != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.nightly_docker_manifest_sha_artifact_name }}
+
+      - name: Terraform Plan
+        if: ${{ inputs.nightly_docker_manifest_sha_artifact_name != '' }}
+        run: |
+          echo "TF_VAR_nightly_docker_manifest_sha=$(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})" >> $GITHUB_ENV
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -94,11 +94,12 @@ jobs:
         with:
           name: ${{ inputs.nightly_docker_manifest_sha_artifact_name }}
 
-      - name: Terraform Plan
+      - name: Export docker manifest sha to TF_VAR
         if: ${{ inputs.nightly_docker_manifest_sha_artifact_name != '' }}
         run: |
-          echo "using docker manifest sha: $(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})"
-          echo "TF_VAR_nightly_docker_manifest_sha=$(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})" >> $GITHUB_ENV
+          docker_manifest_sha=$(cat ${{ inputs.nightly_docker_manifest_sha_artifact_name }})
+          echo "using docker manifest sha: ${docker_manifest_sha}"
+          echo "TF_VAR_nightly_docker_manifest_sha=${docker_manifest_sha}" >> $GITHUB_ENV
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -114,7 +115,7 @@ jobs:
         env:
           TF_CLI_ARGS: "" # workspace does not properly support global options
         run: |
-          terraform workspace select -or-create=true ${{ inputs.workspace }} 
+          terraform workspace select -or-create=true ${{ inputs.workspace }}
 
       - name: Terraform Plan
         if: ${{ inputs.execute_plan }}

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -9,28 +9,40 @@ ROOT_DIR := $(realpath $(THIS_MAKEFILE_DIR)/../..)
 ################
 #### ASSERT ####
 ################
-REQUIRED_BINS := go kind docker awk
-$(foreach bin,$(REQUIRED_BINS),\
-	$(if $(shell command -v $(bin) 2> /dev/null),$(info Found required dependency `$(bin)`),$(error Please install `$(bin)`)))
+.PHONY: assert_require-binary
+assert_require-binary:
+	@{ \
+		for bin in $(REQUIRED_BINS); do \
+			if ! command -v "$$bin" >/dev/null 2>/dev/null; then \
+				echo >&2 "command '$$bin' not found. Please install $$bin"; \
+				exit 1; \
+			else \
+				echo "Found required dependency '$$bin'"; \
+			fi; \
+		done \
+	}
 
 .PHONY: assert_image-tag-present
 assert_image-tag-present:
 	@[ "${IMAGE_TAG}" ] || ( echo ">> env var IMAGE_TAG is not set"; exit 1 )
 
 .PHONY: assert_cluster-exists
-assert_cluster-exists:
+assert_cluster-exists: REQUIRED_BINS=kind go
+assert_cluster-exists: assert_require-binary
 	kind get clusters | grep -q ${KIND_CLUSTER_NAME} || ( echo ">> cluster ${KIND_CLUSTER_NAME} does not exist"; exit 1 )
 
 ################
 ###### CI ######
 ################
 .PHONY: ci_load-image
-ci_load-image: assert_cluster-exists assert_image-tag-present
+ci_load-image: REQUIRED_BINS=kind
+ci_load-image: assert_require-binary assert_cluster-exists assert_image-tag-present
 	kind load docker-image ${IMAGE_REPO}:${IMAGE_TAG} --name ${KIND_CLUSTER_NAME}
 
 .PHONY: ci_build-load-mocked-otlp-image
+ci_build-load-mocked-otlp-image: REQUIRED_BINS=docker kind
 ci_build-load-mocked-otlp-image: BUILD_PATH=${THIS_MAKEFILE_DIR}/mocked_otlp/http
-ci_build-load-mocked-otlp-image: assert_cluster-exists
+ci_build-load-mocked-otlp-image: assert_require-binary assert_cluster-exists
 	docker build -t mocked_otlp:latest -f ${BUILD_PATH}/Dockerfile ${BUILD_PATH}
 	kind load docker-image mocked_otlp:latest --name ${KIND_CLUSTER_NAME}
 
@@ -47,7 +59,8 @@ ci_test-nightly: TEST_MODE=nightlyOnly
 ci_test-nightly: ci_test
 
 .PHONY: ci_test
-ci_test:
+ci_test: REQUIRED_BINS=go
+ci_test: assert_require-binary
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
 	E2E_TEST__DISTRO_TO_TEST=${DISTRO} \


### PR DESCRIPTION
### Summary
- enable artifact support with act ([docs](https://nektosact.com/usage/index.html#action-artifacts))
- pass manifest sha [via artifacts](https://github.com/actions/runner/pull/2477#issuecomment-2037465490) as dynamic output variables are [not supported](https://github.com/actions/runner/pull/2477)  and nightly helm apply [failed for k8s](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13466079899/job/37632896387#step:7:472) b/c it was using the sha of the host distro due to race condition
- add missing checkout to nightly tests as it was split into a different job in a previous PR