### PR TITLE
ci: add release tag workflow

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,39 @@
+name: 📜 Release | Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Get current version
+        run: |
+          version=$(./scripts/get-version.sh)
+          echo "version=$version" >> $GITHUB_ENV
+
+      - name: Check if tag already exists
+        run: |
+          if git rev-parse "${{ env.version }}" >/dev/null 2>&1; then
+            echo "Tag already exists."
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "Tag does not exist."
+            echo "exists=false" >> $GITHUB_ENV
+
+      - name: Create and push tag
+        if: env.exists == 'false'
+        run: |
+          git tag -a "${{ env.version }}" -m "Release version ${{ env.version }}"
+          git push origin "${{ env.version }}"


### PR DESCRIPTION
Adds a workflow that will create a tag in the event a version without a tag is pushed