### PR TITLE
ci: add release token for tagging

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for tag metadata
+          token: ${{ secrets.RELEASE_TOKEN }} # Uses a PAT to ensure subsequent workflows get triggered
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
We need to use a PAT in order to trigger a workflow from a workflow: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow