### PR TITLE
ci: add release publish workflow

### DIFF
--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,4 +1,4 @@
-name: 📜 Release | Draft
+name: 🏷️ Release | Draft
 
 on:
   push:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,0 +1,69 @@
+name: 🏷️ Release | Publish
+
+on:
+  release:
+    types: 
+      - published
+
+env:
+  REGISTRY: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+
+jobs:
+  tag-latest:
+    name: Publish Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distribution:
+          - nrdot-collector-host
+          - nrdot-collector-k8s
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # required for tag metadata
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.OTELCOMM_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.OTELCOMM_DOCKER_HUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OTELCOMM_AWS_TEST_ACC_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}:role/resource-provisioner
+          role-skip-session-tagging: true
+
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY}}/${{ matrix.distribution }}
+
+      - name: Copy Docker Manifest from ECR to Docker Hub
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          image_name="${{ env.REGISTRY }}/${{ matrix.distribution }}"
+
+          if [ -z "$version" ]; then
+            echo "Error: version is empty"
+            exit 1
+          fi
+
+          if ! docker manifest inspect "${image_name}:${version}" > /dev/null 2>&1; then
+            echo "Error: Docker manifest for ${image_name}:${version} does not exist"
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --tag "newrelic/${{ matrix.distribution }}:${version}" \
+            --tag "newrelic/${{ matrix.distribution }}:latest" \
+            "${image_name}:${version}"

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,4 +1,4 @@
-name: 📜 Release | Tag
+name: 🏷️ Release | Tag
 
 on:
   push:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,26 @@ release:
   draft: true
   use_existing_draft: true
   mode: replace
+  header: |
+    ###### !!! REMOVE THIS HEADER BEFORE PUBLISHING !!!
+    ## Release Checklist
+    ### Draft Checklist
+    - [ ] Tests from last nightly build have passed and are stable.
+    - [ ] Release notes below have been reviewed and edited as needed.
+    - [ ] Binaries from each distro have been built and are attached to the release.
+      - [ ] nrdot-collector-host
+      - [ ] nrdot-collector-k8s
+    - [ ] Docker images for each distro have been published to docker hub
+      - [ ] [nrdot-collector-host](https://hub.docker.com/repository/docker/newrelic/nrdot-collector-host/tags) image published and tagged
+      - [ ] [nrdot-collector-k8s](https://hub.docker.com/repository/docker/newrelic/nrdot-collector-k8s/tags) image published and tagged
+    ### Publish Checklist
+    - [ ] Checklist has been reviewed and all items are complete.
+    - [ ] Draft header has been removed.
+    - [ ] Docker images for each distro have been tagged as latest
+      - [ ] [nrdot-collector-host](https://hub.docker.com/repository/docker/newrelic/nrdot-collector-host/tags) version {{ .Version }} tagged as latest
+      - [ ] [nrdot-collector-k8s](https://hub.docker.com/repository/docker/newrelic/nrdot-collector-k8s/tags) version {{ .Version }} tagged as latest
+    - [ ] Slack notifications have been sent to appropriate channels
+    ###### !!! REMOVE THIS HEADER BEFORE PUBLISHING !!!
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
Add a new workflow to handle publishing releases.

Once a release is published we will copy the manifest using [imagetools](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/) from ECR to DockerHub.  Eventually we will cut this step out and simple tag the existing version with `latest`.

Additionally this adds a basic checklist to our release drafts.