### PR TITLE
ci: use shorter cluster names compatible with kind

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -13,7 +13,7 @@ on:
       test_cluster_name:
         required: false
         type: string
-        default: 'ci-e2etest-${{ github.run_id }}-${{ github.run_attempt }}'
+        default: 'ci-${{ github.run_id }}-${{ github.run_attempt }}'
     secrets:
       registry:
         required: false

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -26,7 +26,7 @@ jobs:
     with:
       nightly: true
       distribution: ${{ matrix.distribution }}
-      test_cluster_name: 'ci-e2etest-nightly-${{ matrix.distribution }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      test_cluster_name: '${{ matrix.distribution }}-${{ github.run_id }}-${{ github.run_attempt }}'
     secrets:
       docker_hub_username: ${{ secrets.OTELCOMM_DOCKER_HUB_USERNAME }}
       docker_hub_password: ${{ secrets.OTELCOMM_DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       distribution: ${{ matrix.distribution }}
       # namespace by distro to avoid issues with cleanup (distro 1 still running tests while distro 2 cleans up cluster)
-      test_cluster_name: 'ci-e2etest-${{ matrix.distribution }}-${{ github.run_id }}-${{ github.run_attempt }}'
+      test_cluster_name: '${{ matrix.distribution }}-${{ github.run_id }}-${{ github.run_attempt }}'
     secrets:
       docker_hub_username: ${{ secrets.OTELCOMM_DOCKER_HUB_USERNAME }}
       docker_hub_password: ${{ secrets.OTELCOMM_DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
### Summary
- [Nightly failed](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13546938296/job/37860805144#step:14:31) due to cluster name being too long when I added the run-id + attempt, so removing unnecessary prefixes to hopefully make it work. Most likely limit we're hitting [is 63](https://stackoverflow.com/a/28918017) (couldn't find anything official from kind/docker) as the [docker run](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13546938296/job/37860805144#step:14:38) with hostname `ci-e2etest-nightly-nrdot-collector-host-13546938296-1-control-plane` failed (67 chars).