### PR TITLE
test: remove request spacing behavior in tests

### DIFF
--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -35,9 +35,6 @@ func TestNightly(t *testing.T) {
 	testutil.TagAsNightlyTest(t)
 	testSpec := spec.LoadTestSpec()
 
-	// space out requests to not run into 25 concurrent request limit
-	requestsPerSecond := 4.0
-	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
 	client := nr.NewClient()
 
 	for _, sut := range []spec.NightlySystemUnderTest{ec2Ubuntu22, ec2Ubuntu24, k8sNode} {
@@ -60,8 +57,6 @@ func TestNightly(t *testing.T) {
 						"2 hour ago",
 					)
 					assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
-					// space out requests to avoid rate limiting
-					time.Sleep(time.Duration(counter) * requestSpacing)
 					assertion.ExecuteWithRetries(t, client, 24, 5*time.Second)
 				})
 				counter += 1

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -36,9 +36,6 @@ func TestSlow(t *testing.T) {
 	k8sutil.WaitForCollectorReady(t, kubectlOptions)
 	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
 	time.Sleep(70 * time.Second)
-	// space out requests to not run into 25 concurrent request limit
-	requestsPerSecond := 4.0
-	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
 	client := nr.NewClient()
 
 	testEnvironment := map[string]string{
@@ -59,8 +56,6 @@ func TestSlow(t *testing.T) {
 					"5 minutes ago",
 				)
 				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
-				// space out requests to avoid rate limiting
-				time.Sleep(time.Duration(counter) * requestSpacing)
 				assertion.ExecuteWithRetries(t, client, 24, 5*time.Second)
 			})
 			counter += 1


### PR DESCRIPTION
### Summary
- With query retry in place, we no longer need to artificially space out requests and can instead just run into the rate limit and retry to keep it simple. It also speeds up nightly tests a lot (1min vs 5s locally)
- This should help identify the root cause of [nightly timing out](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13572948183/job/37943719544#step:4:32)