### PR TITLE
ci: fix host.name for host distro in nr_backend

### DIFF
--- a/test/charts/mocked_backend/templates/daemonset.yaml
+++ b/test/charts/mocked_backend/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
               value: "http://validation-backend:4318"
             - name: NEW_RELIC_LICENSE_KEY
               value: "NR_LICENSE_KEY_PLACEHOLDER"
-            # k8s distro expects this to be present
+            {{- if .Values.image.repository | hasSuffix "k8s" }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -41,3 +41,4 @@ spec:
             # used to populate k8s.cluster.name
             - name: K8S_CLUSTER_NAME
               value: {{ .Values.clusterName }}
+            {{- end }}

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -42,13 +42,13 @@ spec:
                 secretKeyRef:
                   name: collector-secrets
                   key: nrIngestKey
-            {{- if .Values.image.repository | hasSuffix "k8s" }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "host.name={{ .Values.collector.hostname }}-$(KUBE_NODE_NAME)"
+            {{- if .Values.image.repository | hasSuffix "k8s" }}
             - name: K8S_CLUSTER_NAME
               value: {{ .Values.clusterName }}
             {{- end }}
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "host.name={{ .Values.collector.hostname }}-$(KUBE_NODE_NAME)"


### PR DESCRIPTION
### Summary
- Fixes that the helm conditionals for the k8s cluster unintentionally also messed up the host name for the host distro.
- Also add conditionals for k8s-only env vars for the mock_backend chart
<img width="468" alt="image" src="https://github.com/user-attachments/assets/728b48f5-1c4f-431a-bc36-537622b9f9fa" />
