### PR TITLE
ci: set cluster name for nightly collectors

### DIFF
--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -52,6 +52,11 @@ resource "helm_release" "ci_e2e_nightly" {
     name  = "collector.hostname"
     value = "${var.test_environment}-${random_string.deploy_id.result}-${var.distro}-k8s_node"
   }
+
+  set {
+    name = "clusterName"
+    value = data.aws_eks_cluster.eks_cluster.name
+  }
 }
 
 module "ci_e2e_ec2" {


### PR DESCRIPTION
### Summary
- Set clustername for nightly helm chart to avoid default cluster name 
<img width="314" alt="image" src="https://github.com/user-attachments/assets/e9617d08-5cf5-4a77-b53c-154e2fb38403" />
