### PR TITLE
docs: flagging k8s distro as preview

### DIFF
--- a/distributions/nrdot-collector-host/README.md
+++ b/distributions/nrdot-collector-host/README.md
@@ -1,5 +1,11 @@
 # nrdot-collector-host
 
+| Status    |                                                                     |
+|-----------|---------------------------------------------------------------------|
+| Distro    | `nrdot-collector-host`                                              |
+| Stability | `public`                                                            |
+| Images    | [DockerHub](https://hub.docker.com/r/newrelic/nrdot-collector-host) |
+
 A distribution of the NRDOT collector focused on
 - monitoring the host the collector is deployed on via `hostmetricsreceiver` and `filelogreceiver`
 - support piping other telemetry through it via the `otlpreceiver`

--- a/distributions/nrdot-collector-k8s/README.md
+++ b/distributions/nrdot-collector-k8s/README.md
@@ -1,5 +1,11 @@
 # nrdot-collector-k8s
 
+| Status    |                                                                    |
+|-----------|--------------------------------------------------------------------|
+| Distro    | `nrdot-collector-k8s`                                              |
+| Stability | `preview`                                                          |
+| Images    | [DockerHub](https://hub.docker.com/r/newrelic/nrdot-collector-k8s) |
+
 Note: See [general README](../README.md) for information that applies to all distributions.
 
 A distribution of the NRDOT collector focused on gathering metrics in a kubernetes environment with two different configs:


### PR DESCRIPTION
In order to indicate that some distros will have differing stability we're opting to note their state in the respective readme files.