### PR TITLE
ci: reduce cloudwatch retention for eks to 1d

### DIFF
--- a/test/terraform/modules/eks_cluster/main.tf
+++ b/test/terraform/modules/eks_cluster/main.tf
@@ -64,6 +64,8 @@ module "eks_cluster" {
   enable_cluster_creator_admin_permissions = true
   iam_role_permissions_boundary            = var.permission_boundary
 
+  cloudwatch_log_group_retention_in_days = 1
+
   eks_managed_node_group_defaults = {
     iam_role_permissions_boundary = var.permission_boundary
 


### PR DESCRIPTION
### Summary
- Reduce cost by limiting cloudwatch retention for the EKS cluster. We don't really use the logs, so reduced it to 1d in case we want to debug something live.