### PR TITLE
feat: remove debug exporter from default host config

### DIFF
--- a/distributions/nrdot-collector-host/config.yaml
+++ b/distributions/nrdot-collector-host/config.yaml
@@ -193,7 +193,6 @@ processors:
     override: true
 
 exporters:
-  debug:
   otlphttp:
     endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT:-https://otlp.nr-data.net}
     headers:
@@ -221,22 +220,22 @@ service:
         - resourcedetection/env
         - cumulativetodelta
         - batch
-      exporters: [debug, otlphttp]
+      exporters: [otlphttp]
     logs/host:
       receivers: [filelog]
       processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
-      exporters: [debug, otlphttp]
+      exporters: [otlphttp]
     traces:
       receivers: [otlp]
       processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
-      exporters: [debug, otlphttp]
+      exporters: [otlphttp]
     metrics:
       receivers: [otlp]
       processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
-      exporters: [debug, otlphttp]
+      exporters: [otlphttp]
     logs:
       receivers: [otlp]
       processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
-      exporters: [debug, otlphttp]
+      exporters: [otlphttp]
 
   extensions: [health_check]


### PR DESCRIPTION
### Summary
- The [debugexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md) is intended for debugging purposes and shouldn't be enabled by default