### PR TITLE
ci: update publish notes pr username

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -12,6 +12,7 @@ jobs:
   tag-latest:
     name: Publish Docker Images
     runs-on: ubuntu-latest
+    if: ${{ !github.event.act }}
     strategy:
       matrix:
         distribution:
@@ -90,12 +91,16 @@ jobs:
           sparse-checkout: src/content/docs/release-notes
 
       - name: Setup ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           version="${{ github.event.release.tag_name }}"
           release_date=$(date -u -d "${{ github.event.release.published_at }}" +"%Y-%m-%d")
+          gh_username=$(gh api user | jq -r '.login')
           echo "release_date=${release_date}" >> $GITHUB_ENV
           echo "version=${version}" >> $GITHUB_ENV
           echo "branch=nrdot-release-notes-${version}-${release_date}" >> $GITHUB_ENV
+          echo "gh_username=${gh_username}" >> $GITHUB_ENV
 
       - name: Commit Release Notes
         run: |
@@ -115,9 +120,10 @@ jobs:
 
           echo "Release notes file created at ${release_notes_file} with:"
           cat $release_notes_file
-
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          
+          git config --global user.name '${{ env.gh_username }}'
+          git config --global user.email '${{ env.gh_username }}@users.noreply.github.com'
           git add $release_notes_file
           git commit -m "feat: Add release notes for NRDOT ${{ env.version }}"
           git push origin ${{ env.branch }}
@@ -130,4 +136,4 @@ jobs:
           gh pr create --title "Add release notes for NRDOT ${{ env.version }}" \
            --body "Add release notes for NRDOT ${{ env.version }}\n\n Note: PR is auto-generated. If anything looks off, please contact the maintainers of ${{ github.event.repository.name }}." \
            --repo newrelic/docs-website \
-           --base develop --head ${{ env.branch }}
+           --base develop --head otelcomm-bot:${{ env.branch }}


### PR DESCRIPTION
Updates the release notes PR to use the current username rather than the generic github actions user.  This allows local users to still run the workflow with their tokens.