### PR TITLE
chore: remove unnecessary init container

### DIFF
--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -17,13 +17,6 @@ spec:
       {{- if .Values.image.repository | hasSuffix "k8s" }}
       serviceAccountName: read-k8s-api-account
       {{- end }}
-      initContainers:
-        # Wait for the backend to be up before starting the collector
-        - name: wait-for-validation
-          image: busybox:latest
-          imagePullPolicy: IfNotPresent
-          command: [ "/bin/sh","-c" ]
-          args: [ 'while [ $(curl -ksw "%{http_code}" "http://validation-backend:8080" -o /dev/null) -ne 200 ]; do sleep 5; echo "health check failed. Waiting for validation service..."; done' ]
       containers:
         - name: *app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
### Summary
- Remove unnecessary `initContainers` for nr_backend chart as it does not contain the validation backend - was accidentally copied from mock-backend