### PR TITLE
ci: prevent bash interpretation of docs

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -116,7 +116,7 @@ jobs:
           echo "metaDescription: Release notes for NRDOT Collector version ${{ env.version }}" >> $release_notes_file
           echo "---" >> $release_notes_file
           echo "" >> $release_notes_file
-          echo "${{ github.event.release.body }}" >> $release_notes_file
+          echo '${{ github.event.release.body }}' >> $release_notes_file
 
           echo "Release notes file created at ${release_notes_file} with:"
           cat $release_notes_file


### PR DESCRIPTION
### Summary
- Double quotes unintentional [caused shell interpretation](https://github.com/newrelic/nrdot-collector-releases/actions/runs/13931159464/job/38988358850#step:5:41) of backtick quoted changelogs.