### PR TITLE
ci: remove host from slow test where clause

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -187,4 +187,5 @@ jobs:
           NR_ACCOUNT_ID=${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }} \
           NR_API_BASE_URL=${{ secrets.NR_STAGING_API_BASE_URL }} \
           DISTRO=${{ matrix.distribution }} \
+          K8S_CONTEXT_NAME=aws-ci-e2etest \
           make -f ./test/e2e/Makefile ci_test-nightly

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -2,11 +2,6 @@ name: 🔄 CI | Nightly Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run the workflow on, e.g. main"
-        type: string
-        required: true
   schedule:
     # Scheduled to run in the morning (PT) on every day-of-week from Monday through Friday.
     - cron: '0 15 * * 1-5'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORELEASER ?= goreleaser
 
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
-OTELCOL_BUILDER_VERSION ?= 0.122.0
+OTELCOL_BUILDER_VERSION ?= 0.122.1
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -8,32 +8,32 @@ dist:
 receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.122.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
 
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.122.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.1
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.122.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.1
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 # replaces:

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -11,15 +11,15 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.122.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
 
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.122.0
@@ -28,19 +28,19 @@ processors:
 
 exporters:
   # shared
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.1
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.122.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.1
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 # replaces:

--- a/distributions/nrdot-collector-k8s/test-spec.yaml
+++ b/distributions/nrdot-collector-k8s/test-spec.yaml
@@ -1,3 +1,8 @@
+whereClause:
+  host:
+    template: "WHERE k8s.cluster.name='{{ .clusterName }}'"
+    vars:
+      - clusterName
 slow:
   testCaseSpecs:
     - k8s

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -5,7 +5,6 @@
 # If they don't, it prints an error message to stderr and exits with status 1.
 
 set -e
-set -x
 
 version=""
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,5 +1,5 @@
 KIND_CLUSTER_NAME ?=e2etest
-K8S_CONTEXT_NAME=kind-${KIND_CLUSTER_NAME}
+K8S_CONTEXT_NAME ?=kind-${KIND_CLUSTER_NAME}
 DISTRO ?=nrdot-collector-host
 IMAGE_REPO ?=newrelic/${DISTRO}
 THIS_MAKEFILE_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -3,6 +3,7 @@ package hostmetrics
 import (
 	"fmt"
 	"test/e2e/util/assert"
+	envutil "test/e2e/util/env"
 	"test/e2e/util/nr"
 	"test/e2e/util/spec"
 	testutil "test/e2e/util/test"
@@ -43,10 +44,17 @@ func TestNightly(t *testing.T) {
 			continue
 		}
 		testEnvironment := map[string]string{
-			"hostName": sut.HostNamePattern,
+			"clusterName": envutil.GetK8sContextName(),
+			"hostName":    sut.HostNamePattern,
 		}
 		for _, testCaseSpecName := range testSpec.Nightly.TestCaseSpecs {
 			testCaseSpec := spec.LoadTestCaseSpec(testCaseSpecName)
+
+			// Allow overriding where clause in distro test specs
+			if clause, exists := testSpec.WhereClause[testCaseSpecName]; exists {
+				testCaseSpec.WhereClause = clause
+			}
+
 			whereClause := testCaseSpec.RenderWhereClause(testEnvironment)
 			counter := 0
 			for caseName, testCase := range testCaseSpec.GetTestCasesWithout(sut.ExcludedMetrics) {

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -39,7 +39,6 @@ func TestSlow(t *testing.T) {
 	client := nr.NewClient()
 
 	testEnvironment := map[string]string{
-		"hostName":    testChart.NrQueryHostNamePattern,
 		"clusterName": kubectlOptions.ContextName,
 	}
 	for _, testCaseSpecName := range testSpec.Slow.TestCaseSpecs {

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -40,9 +40,16 @@ func TestSlow(t *testing.T) {
 
 	testEnvironment := map[string]string{
 		"clusterName": kubectlOptions.ContextName,
+		"hostName":    testChart.NrQueryHostNamePattern,
 	}
 	for _, testCaseSpecName := range testSpec.Slow.TestCaseSpecs {
 		testCaseSpec := spec.LoadTestCaseSpec(testCaseSpecName)
+
+		// Allow overriding where clause in distro test specs
+		if clause, exists := testSpec.WhereClause[testCaseSpecName]; exists {
+			testCaseSpec.WhereClause = clause
+		}
+
 		whereClause := testCaseSpec.RenderWhereClause(testEnvironment)
 		t.Logf("test case spec where clause: %s", whereClause)
 

--- a/test/e2e/util/spec/test_spec.go
+++ b/test/e2e/util/spec/test_spec.go
@@ -9,7 +9,8 @@ import (
 )
 
 type TestSpec struct {
-	Slow struct {
+	WhereClause map[string]RenderableTemplate `yaml:"whereClause"`
+	Slow        struct {
 		TestCaseSpecs []string `yaml:"testCaseSpecs"`
 	} `yaml:"slow"`
 	Nightly struct {

--- a/test/e2e/util/spec/test_spec_test.go
+++ b/test/e2e/util/spec/test_spec_test.go
@@ -1,0 +1,88 @@
+package spec
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	"os"
+	"testing"
+)
+
+func TestLoadTestSpecWithWhereClause(t *testing.T) {
+	expectedSpec := &TestSpec{
+		WhereClause: map[string]RenderableTemplate{
+			"example": {
+				Template: "WHERE var='{{ .var1 }}'",
+				Vars:     []string{"var1"},
+			},
+		},
+		Slow: struct {
+			TestCaseSpecs []string `yaml:"testCaseSpecs"`
+		}{
+			TestCaseSpecs: []string{"test1", "test2"},
+		},
+		Nightly: struct {
+			EC2 struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"ec2"`
+			TestCaseSpecs []string `yaml:"testCaseSpecs"`
+		}{
+			EC2: struct {
+				Enabled bool `yaml:"enabled"`
+			}{
+				Enabled: true,
+			},
+			TestCaseSpecs: []string{"nightlyTest1", "nightlyTest2"},
+		},
+	}
+
+	testSpecFile := "testdata/test-spec-with-where.yaml"
+	testSpecData, err := os.ReadFile(testSpecFile)
+	if err != nil {
+		t.Fatalf("failed to read test spec file: %v", err)
+	}
+
+	var testSpec TestSpec
+	err = yaml.Unmarshal(testSpecData, &testSpec)
+	if err != nil {
+		t.Fatalf("failed to unmarshal test spec: %v", err)
+	}
+
+	assert.Equal(t, expectedSpec, &testSpec)
+}
+
+func TestLoadTestSpecWithoutWhereClause(t *testing.T) {
+	expectedSpec := &TestSpec{
+		Slow: struct {
+			TestCaseSpecs []string `yaml:"testCaseSpecs"`
+		}{
+			TestCaseSpecs: []string{"test1", "test2"},
+		},
+		Nightly: struct {
+			EC2 struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"ec2"`
+			TestCaseSpecs []string `yaml:"testCaseSpecs"`
+		}{
+			EC2: struct {
+				Enabled bool `yaml:"enabled"`
+			}{
+				Enabled: true,
+			},
+			TestCaseSpecs: []string{"nightlyTest1", "nightlyTest2"},
+		},
+	}
+
+	testSpecFile := "testdata/test-spec-without-where.yaml"
+	testSpecData, err := os.ReadFile(testSpecFile)
+	if err != nil {
+		t.Fatalf("failed to read test spec file: %v", err)
+	}
+
+	var testSpec TestSpec
+	err = yaml.Unmarshal(testSpecData, &testSpec)
+	if err != nil {
+		t.Fatalf("failed to unmarshal test spec: %v", err)
+	}
+
+	assert.Equal(t, expectedSpec, &testSpec)
+}

--- a/test/e2e/util/spec/testdata/test-spec-with-where.yaml
+++ b/test/e2e/util/spec/testdata/test-spec-with-where.yaml
@@ -1,3 +1,8 @@
+whereClause:
+  example:
+    template: "WHERE var='{{ .var1 }}'"
+    vars:
+      - "var1"
 slow:
   testCaseSpecs:
     - "test1"

--- a/test/e2e/util/spec/testdata/test-spec-without-where.yaml
+++ b/test/e2e/util/spec/testdata/test-spec-without-where.yaml
@@ -1,0 +1,15 @@
+whereClause:
+  example:
+    template: "WHERE var='{{ .var1 }}'"
+    vars:
+      - "var1"
+slow:
+  testCaseSpecs:
+    - "test1"
+    - "test2"
+nightly:
+  ec2:
+    enabled: true
+  testCaseSpecs:
+    - "nightlyTest1"
+    - "nightlyTest2"


### PR DESCRIPTION
Allows for overriding test spec where clause per distro to account for differences in configs, particularly k8s dropping the resourcedetection/ env config.  Also updates otel components to the latest patch version.