### PR TITLE
test: remove system.paging.usage tests

### DIFF
--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -13,23 +13,18 @@ import (
 
 var ec2Ubuntu22 = spec.NightlySystemUnderTest{
 	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu22_04"),
-	// TODO: NR-362121
-	ExcludedMetrics: []string{"system.paging.usage"},
 	SkipIf: func(testSpec *spec.TestSpec) bool {
 		return !testSpec.Nightly.EC2.Enabled
 	},
 }
 var ec2Ubuntu24 = spec.NightlySystemUnderTest{
 	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
-	// TODO: NR-362121
-	ExcludedMetrics: []string{"system.paging.usage"},
 	SkipIf: func(testSpec *spec.TestSpec) bool {
 		return !testSpec.Nightly.EC2.Enabled
 	},
 }
 var k8sNode = spec.NightlySystemUnderTest{
 	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),
-	ExcludedMetrics: []string{"system.paging.usage"},
 }
 
 func TestNightly(t *testing.T) {

--- a/test/e2e/util/spec/host.yaml
+++ b/test/e2e/util/spec/host.yaml
@@ -184,22 +184,6 @@ testCases:
       - aggregationFunction: max
         comparisonOperator: ">="
         threshold: 0
-  host_receiver_paging.usage_used:
-    metric:
-      name: system.paging.usage
-      whereClause: WHERE state='used'
-    assertions:
-      - aggregationFunction: max
-        comparisonOperator: ">="
-        threshold: 0
-  host_receiver_paging.usage_free:
-    metric:
-      name: system.paging.usage
-      whereClause: WHERE state='free'
-    assertions:
-      - aggregationFunction: max
-        comparisonOperator: ">"
-        threshold: 0
   host_receiver_inodes.usage_free:
     metric:
       name: system.filesystem.inodes.usage

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -123,12 +123,6 @@ resource "aws_instance" "ubuntu" {
   user_data_replace_on_change = true
   user_data                   = <<-EOF
               #!/bin/bash
-              echo 'Configuring swap file to ensure system.paging.usage metric gets published'
-              dd if=/dev/zero of=/swapfile bs=1M count=128
-              chmod 600 /swapfile
-              mkswap /swapfile
-              swapon /swapfile
-              swapon -s
               ################################################
               echo 'Installing Collector'
               export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Summary
- Remove `system.paging.usage` tests as maintaining testing infra to reliably emit this metric turns out to be too much effort