### PR TITLE
feat: bumping otel components to 0.123.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORELEASER ?= goreleaser
 
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
-OTELCOL_BUILDER_VERSION ?= 0.122.1
+OTELCOL_BUILDER_VERSION ?= 0.123.0
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -6,34 +6,34 @@ dist:
   output_path: ./_build
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.122.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.123.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.123.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.123.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.123.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.123.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.123.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.123.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.123.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.123.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.29.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 # replaces:

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -6,41 +6,41 @@ dist:
   output_path: ./_build
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.122.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.123.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.123.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.122.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.122.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.123.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.123.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.123.0
 
 exporters:
   # shared
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.123.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.123.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.123.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.122.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.123.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.29.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.29.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 # replaces:


### PR DESCRIPTION
Bumping components to `0.123.0`, should address the CVE from https://github.com/newrelic/nrdot-collector-releases/pull/291