### PR TITLE
feat: configure memory_limiter for all pipelines

### DIFF
--- a/distributions/nrdot-collector-host/config.yaml
+++ b/distributions/nrdot-collector-host/config.yaml
@@ -223,19 +223,19 @@ service:
       exporters: [otlphttp]
     logs/host:
       receivers: [filelog]
-      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [otlphttp]
     traces:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [otlphttp]
     metrics:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [otlphttp]
     logs:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [otlphttp]
 
   extensions: [health_check]


### PR DESCRIPTION
### Summary
- Implementing best practices for batchprocessor and memorylimiterprocessor
- [batch](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.124.0/processor/batchprocessor) should be after memory and any dropping processor. This is the case for both distros as it's the last processor in all pipelines
> It is highly recommended to configure the batch processor on every collector. The batch processor should be defined in the pipeline after the memory_limiter as well as any sampling processors. This is because batching should happen after any data drops such as sampling.
- [memorylimiter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.124.0/processor/memorylimiterprocessor#best-practices) should be first for all pipelines
   - k8s distro was fixed upstream in [this PR](https://github.com/newrelic/helm-charts/pull/1691) and downstream propagation is included in #300 
> For the memory_limiter processor, the best practice is to add it as the first processor in a pipeline. This is to ensure that backpressure can be sent to applicable receivers and minimize the likelihood of dropped data when the memory_limiter gets triggered.