### PR TITLE
Add the routing connector to the K8s NRDOT distro

### DIFF
--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -32,6 +32,9 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.123.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.123.0
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.123.0
+
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.123.0
 


### PR DESCRIPTION
To enhance customizability of the OTel connector configs/pipelines we want to introduce the connector component to the K8s Helm chart. In order to do so, we need NRDOT to support connectors.

[Relevant Jira Ticket](https://new-relic.atlassian.net/browse/NR-383421)