### PR TITLE
Add the routing connector to the K8s NRDOT distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Our intention is that each distribution we maintain serves a specific use case p
 However, this also means that we need to be deliberate about the components we include in a distribution. Our current
 philosophy is that we will only add a new component to a distribution if
 - it is required to support the use case of the distribution
-- we consider it essential for all distributions, e.g. `debugexporter` or `healthcheckextension`
+- we consider it [essential ](./distributions/core-components.md) for all distributions
 Our goal is to work with customers and internal teams to iteratively create new distributions when a strong enough use case has been developed and the components to support it have been identified.
 
 Please note that while the set of distributions is still limited, we encourage you to also explore the distributions provided by the [OpenTelemetry community](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions). In particular the `contrib` distribution can be helpful as a stopgap solution as it includes all core and contrib components.

--- a/distributions/core-components.md
+++ b/distributions/core-components.md
@@ -1,0 +1,14 @@
+# Core Components
+This document describes the core components of the NRDOT distribution which should be included in all distributions.
+
+| Component                                | Reason                                                                                       |
+|------------------------------------------|----------------------------------------------------------------------------------------------|
+| `otlpreceiver`                           | Basic OTLP-based gateway capabilities                                                        |
+| `batchprocessor`                         | Performance optimization                                                                     |
+| `memorylimiterprocessor`                 | Reliability - Control over resource usage                                                    |
+| `routingconnector`                       | Reduce config redundancy for complex pipelines, e.g. multiple NR accounts based on attributes |
+| `otlpexporter`                           | Required to write to NR OTLP endpoint via HTTP                                               |
+| `otlphttpexporter`                       | Required to write to NR OTLP endpoint via gRPC                                               |
+| `debugexporter`                          | Debugging, testing, config validation                                                        |
+| `healthcheckextension`                   | Reliability - Basic health check capabilities                                                |
+| `[env\|file\|http\|https\|yaml]provider` | Configuration from various sources |

--- a/distributions/nrdot-collector-host/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-host/THIRD_PARTY_NOTICES.md
@@ -12,6 +12,14 @@ can be found at https://github.com/newrelic/nrdot-collector-releases.
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -25,6 +25,9 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.125.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.125.0
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.125.0
+
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0
 

--- a/distributions/nrdot-collector-k8s/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-k8s/THIRD_PARTY_NOTICES.md
@@ -12,6 +12,14 @@ can be found at https://github.com/newrelic/nrdot-collector-releases.
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -32,6 +32,9 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.125.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.125.0
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.125.0
+
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0
 

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -27,7 +27,6 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.125.0
 
 exporters:
-  # shared
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.125.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.125.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.125.0


### PR DESCRIPTION
To enhance customizability of the OTel connector configs/pipelines we want to introduce the connector component to the K8s Helm chart. In order to do so, we need NRDOT to support connectors.

[Relevant Jira Ticket](https://new-relic.atlassian.net/browse/NR-383421)