### PR TITLE
ci: ensure conventional commit PR title

### DIFF
--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -16,9 +16,10 @@ jobs:
       # Low-tech linter to avoid squashing commits into non-semantic conventional commit by addressing the most common cause
       - name: Assert PR name adhering to conventional commits
         run: |
-          pr_title=$(gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title)
-          echo "${pr_title}" |
+          pr_title_json=$(gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title)
+          echo "${pr_title_json}" |
           jq --args '.title | test("\\w+: \\w+")' -e 1 || {
+            pr_title=$(echo "${pr_title_json}" | jq -r '.title')
             gh pr --repo ${{ github.repository }} comment ${{ github.event.number }} \
               --body "PR title '${pr_title}' does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
           }

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -16,8 +16,9 @@ jobs:
       # Low-tech linter to avoid squashing commits into non-semantic conventional commit by addressing the most common cause
       - name: Assert PR name adhering to conventional commits
         run: |
-          gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title |
-            jq --args '.title | test("\\w+: \\w+")' -e 1 || {
-            gh pr comment ${{ github.event.number }} \
-              --body "PR title does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
+          pr_title=$(gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title)
+          echo "${pr_title}" |
+          jq --args '.title | test("\\w+: \\w+")' -e 1 || {
+            gh pr --repo ${{ github.repository }} comment ${{ github.event.number }} \
+              --body "PR title '${pr_title}' does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
           }

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -22,4 +22,5 @@ jobs:
             pr_title=$(echo "${pr_title_json}" | jq -r '.title')
             gh pr --repo ${{ github.repository }} comment ${{ github.event.number }} \
               --body "PR title '${pr_title}' does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
+            exit 1
           }

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -1,0 +1,22 @@
+name: 🔄 Lint | Conventional Commits
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  GH_TOKEN: ${{ github.token }}
+permissions:
+  pull-requests: write
+jobs:
+  check-pr-name:
+    runs-on: ubuntu-latest
+    steps:
+      # Low-tech linter to avoid squashing commits into non-semantic conventional commit by addressing the most common cause
+      - name: Assert PR name adhering to conventional commits
+        run: |
+          gh pr view ${{ github.event.number }} --json title
+            | jq --args '.title | test("\\w+: \\w+")' -e 1 || {
+            gh pr comment ${{ github.event.number }} \
+              --body "PR title does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
+          }

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -15,8 +15,8 @@ jobs:
       # Low-tech linter to avoid squashing commits into non-semantic conventional commit by addressing the most common cause
       - name: Assert PR name adhering to conventional commits
         run: |
-          gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title
-            | jq --args '.title | test("\\w+: \\w+")' -e 1 || {
+          gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title |
+            jq --args '.title | test("\\w+: \\w+")' -e 1 || {
             gh pr comment ${{ github.event.number }} \
               --body "PR title does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."
           }

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -2,6 +2,7 @@ name: 🔄 Lint | Conventional Commits
 
 on:
   pull_request:
+    types: [opened, edited]
     branches: [main]
 
 env:

--- a/.github/workflows/lint-conventional-commits.yaml
+++ b/.github/workflows/lint-conventional-commits.yaml
@@ -15,7 +15,7 @@ jobs:
       # Low-tech linter to avoid squashing commits into non-semantic conventional commit by addressing the most common cause
       - name: Assert PR name adhering to conventional commits
         run: |
-          gh pr view ${{ github.event.number }} --json title
+          gh pr --repo ${{ github.repository }} view ${{ github.event.number }} --json title
             | jq --args '.title | test("\\w+: \\w+")' -e 1 || {
             gh pr comment ${{ github.event.number }} \
               --body "PR title does not adhere to conventional commits. Change PR title to ensure that the suggested squash commit follows the conventions and thus ends up in the changelog."


### PR DESCRIPTION
### Summary
- Simple workflow to validate PR title to avoid the suggested commit message to not adhere to conventional commits and therefore end up excluded from the auto-generated changelogs in the draft release.
- If it fails, it comments (like [here](https://github.com/newrelic/nrdot-collector-releases/pull/307#issuecomment-2855943630) when I removed the `ci:` prefix from the title) and fails the workflow