### PR TITLE
feat: Ensure cli builder uses proper version of the collector

### DIFF
--- a/cmd/nrdot-collector-builder/cmd/manifest.go
+++ b/cmd/nrdot-collector-builder/cmd/manifest.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"newrelic-collector-builder/cmd/manifest"
 
 	"github.com/spf13/cobra"

--- a/cmd/nrdot-collector-builder/internal/manifest/config_test.go
+++ b/cmd/nrdot-collector-builder/internal/manifest/config_test.go
@@ -85,3 +85,38 @@ func TestConfig_IsOtelContribComponent(t *testing.T) {
 	assert.True(t, isOtelContribComponent("github.com/open-telemetry/opentelemetry-collector-contrib/component"))
 	assert.False(t, isOtelContribComponent("github.com/some/other/module"))
 }
+
+func TestConfig_SetVersions(t *testing.T) {
+	cfg := &Config{
+		Extensions: []Module{
+			{GoMod: "github.com/open-telemetry/opentelemetry-collector-contrib/component v0.1.0"},
+		},
+		Receivers: []Module{
+			{GoMod: "go.opentelemetry.io/collector v1.0.0"},
+			{GoMod: "go.opentelemetry.io/collector/component v0.1.0"},
+		},
+	}
+
+	err := cfg.SetVersions()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "v1.0.0", cfg.Versions.StableCoreVersion)
+	assert.Equal(t, "v0.1.0", cfg.Versions.BetaCoreVersion)
+	assert.Equal(t, "v0.1.0", cfg.Versions.BetaContribVersion)
+}
+
+func TestConfig_SetVersions_MissingCore(t *testing.T) {
+	cfg := &Config{
+		Extensions: []Module{
+			{GoMod: "github.com/open-telemetry/opentelemetry-collector-contrib/component v0.1.0"},
+		},
+		Receivers: []Module{
+			{GoMod: "go.opentelemetry.io/collector v1.0.0"},
+		},
+	}
+
+	err := cfg.SetVersions()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing beta core version")
+
+}

--- a/cmd/nrdot-collector-builder/internal/manifest/main.go
+++ b/cmd/nrdot-collector-builder/internal/manifest/main.go
@@ -156,7 +156,7 @@ func CopyAndUpdateConfigModules(cfg *Config, updates map[string][]string) (*Conf
 	cfgCopy.ConfmapProviders = update(cfg.ConfmapProviders)
 	cfgCopy.ConfmapConverters = update(cfg.ConfmapConverters)
 
-	cfgCopy.SetOtelColVersion()
+	cfgCopy.SetVersions()
 
 	return &cfgCopy, nil
 }

--- a/scripts/bump-component-versions.sh
+++ b/scripts/bump-component-versions.sh
@@ -1,70 +1,28 @@
 #!/bin/bash
 set -e
 
+GO=''
 
-# Function to validate semantic version and strip leading 'v'
-validate_and_strip_version() {
-  local var_name=$1
-  local version=${!var_name}
-  # Strip leading 'v' if present
-  version=${version#v}
-  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Invalid version: $version. Must be a semantic version (e.g., 1.2.3)."
-    exit 1
-  fi
-  eval "$var_name='$version'"
-}
+while getopts d:g: flag
+do
+    case "${flag}" in
+        g) GO=${OPTARG};;
+        *) exit 1;;
+    esac
+done
 
+[[ -n "$GO" ]] || GO='go'
 
-# Get the most recent release tag from the open-telemetry/opentelemetry-collector-contrib repo
-get_latest_otel_release_tag() {
-    local repo="open-telemetry/opentelemetry-collector-releases"
-    local latest_tag=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | jq -r .tag_name)
-    if [[ -z $latest_tag ]]; then
-        echo "Failed to fetch the latest release tag from $repo."
-        exit 1
-    fi
-    
-    validate_and_strip_version latest_tag
-    echo "$latest_tag"
-}
+# Store the current directory
+ORIGINAL_DIR=$(pwd)
 
+# Change to the CLI tool directory
+cd "$(dirname "$0")/../cmd/nrdot-collector-builder" || exit 1
 
-otel_version=$(get_latest_otel_release_tag)
-manifest_url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v${otel_version}/distributions/otelcol/manifest.yaml"
-manifest_content=$(curl --silent "$manifest_url")
+OUTPUT=$(${GO} run main.go manifest update --json --config "../../distributions/*/manifest.yaml")
 
-# Extract the distribution version from the manifest content
-next_beta_core=$(echo "$manifest_content" | awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}')
-next_beta_contrib=$(echo "$manifest_content" | awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}')
-next_stable=$(echo "$manifest_content" | awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}')
-
-validate_and_strip_version next_beta_core
-validate_and_strip_version next_beta_contrib
-validate_and_strip_version next_stable
-
-echo "Next beta core version: $next_beta_core"
-echo "Next beta contrib version: $next_beta_contrib"
-echo "Next stable version: $next_stable"
-
-# Get the current versions from the manifest.yaml files
-current_beta_core=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v0/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
-current_beta_contrib=$(awk '/^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.* v0/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
-current_stable=$(awk '/^.*go\.opentelemetry\.io\/collector\/.* v1/ {print $4; exit}' distributions/nrdot-collector-host/manifest.yaml)
-
-validate_and_strip_version current_beta_core
-validate_and_strip_version current_beta_contrib
-validate_and_strip_version current_stable
-
-echo "Current beta core version: $current_beta_core"
-echo "Current beta contrib version: $current_beta_contrib"
-echo "Current stable version: $current_stable"
-
-
-# add escape characters to the current versions to work with sed
-escaped_current_beta_core=${current_beta_core//./\\.}
-escaped_current_beta_contrib=${current_beta_contrib//./\\.}
-escaped_current_stable=${current_stable//./\\.}
+# Return to the original directory
+cd "$ORIGINAL_DIR" || exit 1
 
 # Determine the OS and set the sed -i command accordingly
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -78,19 +36,18 @@ else
   }
 fi
 
-# Update versions in each manifest file
-echo "Updating core beta version from $current_beta_core to $next_beta_core,"
-echo "core stable version from $current_stable to $next_stable,"
-echo "contrib beta version from $current_beta_contrib to $next_beta_contrib,"
-for file in ./distributions/*/manifest.yaml; do
-  if [ -f "$file" ]; then
-    sed_inplace "s/\(^.*go\.opentelemetry\.io\/collector\/.*\) v$escaped_current_beta_core/\1 v$next_beta_core/" "$file"
-    sed_inplace "s/\(^.*github\.com\/open-telemetry\/opentelemetry-collector-contrib\/.*\) v$escaped_current_beta_contrib/\1 v$next_beta_contrib/" "$file"
-    sed_inplace "s/\(^.*go\.opentelemetry\.io\/collector\/.*\) v$escaped_current_stable/\1 v$next_stable/" "$file"
-  else
-    echo "File $file does not exist"
-  fi
-done
+# Extract the current beta core version
+current_beta_core=$(echo "$OUTPUT" | jq -r '.currentVersions.betaCoreVersion')
+current_beta_core=${current_beta_core#v}
+escaped_current_beta_core=${current_beta_core//./\\.}
+next_beta_core=$(echo "$OUTPUT" | jq -r '.nextVersions.betaCoreVersion')
+next_beta_core=${next_beta_core#v}
 
-# Update Makefile OCB version
-sed_inplace "s/OTELCOL_BUILDER_VERSION ?= $escaped_current_beta_core/OTELCOL_BUILDER_VERSION ?= $next_beta_core/" Makefile
+#  If the current beta core version is not equal to the next beta core version, update the Makefile
+if [[ "$current_beta_core" != "$next_beta_core" ]]; then
+  echo "Updating Makefile from $current_beta_core to $next_beta_core"
+  # Update Makefile OCB version
+  sed_inplace "s/OTELCOL_BUILDER_VERSION ?= $escaped_current_beta_core/OTELCOL_BUILDER_VERSION ?= $next_beta_core/" Makefile
+else
+  echo "No update needed for the Makefile."
+fi


### PR DESCRIPTION
Updates the builder cli to parse for beta core/contrib and stable core versions.  The also updates the version bump script to use the cli.