### PR TITLE
fix: Fix pr generation on version bump

### DIFF
--- a/.github/workflows/ci-bump-component-versions.yaml
+++ b/.github/workflows/ci-bump-component-versions.yaml
@@ -6,6 +6,10 @@ on:
     # Scheduled to run every hour on every day-of-week from Monday through Friday.
     - cron: '0 * * * 1-5'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
     bump:
         name: Bump Component Versions
@@ -15,6 +19,21 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0 # required for tag metadata
+            token: ${{ secrets.RELEASE_TOKEN }}
+            ref: main
+
+        - name: Import GPG key
+          uses: crazy-max/ghaction-import-gpg@v6
+          with:
+            gpg_private_key: ${{ secrets.OTELCOMM_BOT_GPG_PRIVATE_KEY_BASE64 }}
+            passphrase: ${{ secrets.OTELCOMM_BOT_GPG_PASSPHRASE }}
+            git_user_signingkey: true
+            git_commit_gpgsign: true
+
+        - name: Set up Git
+          run: |
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
     
         - name: Setup Go
           uses: actions/setup-go@v5
@@ -37,41 +56,87 @@ jobs:
             else
               echo "Unstaged changes found. Continuing..."
               echo "has_changes=true" >> $GITHUB_OUTPUT
+              next_beta_core=$(echo "${output}" | jq -r '.nextVersions.betaCoreVersion')
+              current_beta_core=$(echo "${output}" | jq -r '.currentVersions.betaCoreVersion')
+              echo "next_beta_core=${next_beta_core}" >> $GITHUB_ENV
+              echo "current_beta_core=${current_beta_core}" >> $GITHUB_ENV
+              echo "branch=otel-release/${next_beta_core}" >> $GITHUB_ENV
             fi
-
-        - name: Setup ENV
-          if: steps.bump_component_versions.outputs.has_changes == 'true'
-          env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          run: |
-            gh_username=$(gh api user | jq -r '.login')
-            output=$(echo "${{ steps.bump_component_versions.outputs.output }}")
-            echo "gh_username=${gh_username}" >> $GITHUB_ENV
-            next_beta_core=$(echo "${output}" | jq -r '.nextVersions.betaCoreVersion')
-            current_beta_core=$(echo "${output}" | jq -r '.currentVersions.betaCoreVersion')
-            echo "next_beta_core=${next_beta_core}" >> $GITHUB_ENV
-            echo "current_beta_core=${current_beta_core}" >> $GITHUB_ENV
-            echo "branch=otel-release/${next_beta_core}" >> $GITHUB_ENV
 
         - name: Commit Component Version Bump
           if: steps.bump_component_versions.outputs.has_changes == 'true'
-          env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           run: |
-            git switch -c ${{ env.branch }}
-            git config --global user.name '${{ env.gh_username }}'
-            git config --global user.email '${{ env.gh_username }}@users.noreply.github.com'
-
+            # Check if branch exists remotely
+            if git ls-remote --heads origin ${{ env.branch }} | grep -q ${{ env.branch }}; then
+              echo "Branch ${{ env.branch }} already exists, will be updated with local changes"
+              git fetch origin ${{ env.branch }}:refs/remotes/origin/${{ env.branch }}
+              
+              # Create new branch from current changes
+              git switch -c temp-branch
+              
+              # Force reset the existing branch to match main
+              git checkout ${{ env.branch }} || git checkout -b ${{ env.branch }}
+              git reset --hard origin/main
+              
+              # Apply our changes from temp branch (like a rebase)
+              git checkout temp-branch -- .
+            else
+              echo "Creating new branch ${{ env.branch }}"
+              git switch -c ${{ env.branch }}
+            fi
+            
+            # Continue with commit and push
             git add --all
-            git commit -m "feat: Bump otel component versions from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}"
-            git push origin ${{ env.branch }}
+            git commit -S -m "feat: Bump otel component versions from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}"
+            git push --force origin ${{ env.branch }}
             
         - name: Issue PR
           if: ${{ !env.ACT && steps.bump_component_versions.outputs.has_changes == 'true' }}
           env:
             GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           run: |
-            gh pr create --title "Bump OTEL beta core to ${{ env.next_beta_core }}" \
-            --body "Updates the version of the otel beta core from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}." \
-            --repo ${{ github.event.repository.name }} \
-            --base main --head ${{ github.event.repository.name }}:${{ env.branch }}
+            pr_title="feat: Bump OTEL beta core to ${{ env.next_beta_core }}"
+            pr_body="Updates the version of the otel beta core from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}"
+            
+            # Find all open PRs with branches matching the pattern 'otel-release/v0*'
+            echo "Searching for existing upgrade PRs to close..."
+            old_prs=$(gh pr list --search "head:otel-release/v0" --state open --json number,headRefName --jq '.[] | select(.headRefName != "${{ env.branch }}")')
+            
+            # Close each PR except for the current branch's PR
+            if [ -n "$old_prs" ]; then
+              echo "$old_prs" | jq -c '.' | while read -r pr; do
+                pr_number=$(echo "$pr" | jq -r '.number')
+                pr_branch=$(echo "$pr" | jq -r '.headRefName')
+                
+                echo "Closing PR #$pr_number (branch: $pr_branch) as superseded by new PR"
+                gh pr close $pr_number --repo "${{ github.repository }}" --comment "Closing in favor of newer version upgrade PR for ${{ env.next_beta_core }}"
+              done
+            else
+              echo "No older upgrade PRs found to close"
+            fi
+
+            # Check if PR already exists for this branch
+            pr_exists=$(gh pr list --head "${{ env.branch }}" --json number --jq 'length')
+
+            if [ "$pr_exists" -gt "0" ]; then
+              echo "PR already exists for branch ${{ env.branch }}, updating..."
+              
+              # Get the PR number
+              pr_number=$(gh pr list --repo "${{ github.repository }}" --head "${{ env.branch }}" --json number --jq '.[0].number')
+              
+              # Update the PR title and body
+              gh pr edit $pr_number \
+                --repo "${{ github.repository }}" \
+                --title "$pr_title" \
+                --body "$pr_body"
+              
+              echo "Updated PR #$pr_number"
+            else
+              echo "Creating new PR..."
+              gh pr create \
+                --title "$pr_title" \
+                --body "$pr_body" \
+                --repo "${{ github.repository }}" \
+                --base main \
+                --head "${{ env.branch }}"
+            fi

--- a/.github/workflows/ci-bump-component-versions.yaml
+++ b/.github/workflows/ci-bump-component-versions.yaml
@@ -58,8 +58,12 @@ jobs:
               echo "has_changes=true" >> $GITHUB_OUTPUT
               next_beta_core=$(echo "${output}" | jq -r '.nextVersions.betaCoreVersion')
               current_beta_core=$(echo "${output}" | jq -r '.currentVersions.betaCoreVersion')
+              next_beta_contrib=$(echo "${output}" | jq -r '.nextVersions.betaContribVersion')
+              current_beta_contrib=$(echo "${output}" | jq -r '.currentVersions.betaContribVersion')
               echo "next_beta_core=${next_beta_core}" >> $GITHUB_ENV
               echo "current_beta_core=${current_beta_core}" >> $GITHUB_ENV
+              echo "next_beta_contrib=${next_beta_contrib}" >> $GITHUB_ENV
+              echo "current_beta_contrib=${current_beta_contrib}" >> $GITHUB_ENV
               echo "branch=otel-release/${next_beta_core}" >> $GITHUB_ENV
             fi
 
@@ -68,23 +72,14 @@ jobs:
           run: |
             # Check if branch exists remotely
             if git ls-remote --heads origin ${{ env.branch }} | grep -q ${{ env.branch }}; then
-              echo "Branch ${{ env.branch }} already exists, will be updated with local changes"
-              git fetch origin ${{ env.branch }}:refs/remotes/origin/${{ env.branch }}
-              
-              # Create new branch from current changes
-              git switch -c temp-branch
-              
-              # Force reset the existing branch to match main
-              git checkout ${{ env.branch }} || git checkout -b ${{ env.branch }}
-              git reset --hard origin/main
-              
-              # Apply our changes from temp branch (like a rebase)
-              git checkout temp-branch -- .
+              echo "Branch ${{ env.branch }} already exists, will be recreated from main"
+              # Create new branch from main - no need to fetch existing branch
+              git checkout -b ${{ env.branch }} origin/main
             else
               echo "Creating new branch ${{ env.branch }}"
               git switch -c ${{ env.branch }}
             fi
-            
+                        
             # Continue with commit and push
             git add --all
             git commit -S -m "feat: Bump otel component versions from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}"
@@ -96,7 +91,11 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           run: |
             pr_title="feat: Bump OTEL beta core to ${{ env.next_beta_core }}"
-            pr_body="Updates the version of the otel beta core from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}"
+            pr_body="Updates the version of the otel beta core from ${{ env.current_beta_core }} to ${{ env.next_beta_core }}
+            ## Changes
+              - Beta Core: [${{ env.current_beta_core}}...${{ env.next_beta_core}}](https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/${{ env.current_beta_core}}...${{ env.next_beta_core}})
+              - Beta Contrib: [${{ env.current_beta_contrib}}...${{ env.next_beta_contrib}}](https://github.com/open-telemetry/opentelemetry-collector/compare/${{ env.current_beta_contrib}}...${{ env.next_beta_contrib}})
+            "
             
             # Find all open PRs with branches matching the pattern 'otel-release/v0*'
             echo "Searching for existing upgrade PRs to close..."


### PR DESCRIPTION
Needed to fix a few things around git commits, also improved a few things:

- Handles cases where remote branch already exists
- Closes prs for older prs that are still open
- Updates pr if it already exists

Here is a link to the successful run: https://github.com/newrelic/nrdot-collector-releases/pull/316