### PR TITLE
feat: sync k8s config from nr-k8s-otel-collector v0.8.26

### DIFF
--- a/distributions/nrdot-collector-k8s/config-daemonset.yaml
+++ b/distributions/nrdot-collector-k8s/config-daemonset.yaml
@@ -199,7 +199,7 @@ processors:
             new_value: 'false'
   metricstransform/kubeletstats:
     transforms:
-      - include: container\.(cpu\.usage|filesystem\.(capacity|usage)|memory\.usage)
+      - include: container\.(cpu\.usage|filesystem\.(available|capacity|usage)|memory\.usage)
         action: update
         match_type: regexp
         operations:
@@ -238,6 +238,15 @@ processors:
               - value: 'false'
                 new_value: 'true'
       - include: container_memory_working_set_bytes
+        action: update
+        match_type: regexp
+        operations:
+          - action: update_label
+            label: low.data.mode
+            value_actions:
+              - value: 'false'
+                new_value: 'true'
+      - include: container_memory_mapped_file
         action: update
         match_type: regexp
         operations:

--- a/distributions/nrdot-collector-k8s/config-deployment.yaml
+++ b/distributions/nrdot-collector-k8s/config-deployment.yaml
@@ -295,7 +295,7 @@ processors:
             value_actions:
               - value: 'false'
                 new_value: 'true'
-      - include: kube_node_status_(allocatable|condition)
+      - include: kube_node_status_(allocatable|capacity|condition)
         action: update
         match_type: regexp
         operations:
@@ -448,12 +448,9 @@ processors:
         action: delete
   resource/events:
     attributes:
-      - key: "event.name"
+      - key: "newrelic.event.type"
         action: upsert
-        value: "InfrastructureEvent"
-      - key: "event.domain"
-        action: upsert
-        value: "newrelic-otel-event"
+        value: "OtlpInfrastructureEvent"
       - key: "category"
         action: upsert
         value: "kubernetes"

--- a/distributions/nrdot-collector-k8s/sync-configs.sh
+++ b/distributions/nrdot-collector-k8s/sync-configs.sh
@@ -30,9 +30,6 @@ function extract_config_with_overwritable_defaults() {
     } | {
       # remove configuration requiring mounted host filesystem
       yq 'del(.receivers.hostmetrics.root_path)'
-      } | {
-      # temporarily remove unused debug exporter until fixed upstream
-      yq 'del(.exporters.debug)'
     } | {
       # expose ingest endpoint via env var to align with other distros
       sed 's/"https:\/\/otlp.nr-data.net"/${env:OTEL_EXPORTER_OTLP_ENDPOINT:-https:\/\/otlp.nr-data.net}/g'
@@ -50,6 +47,18 @@ function extract_config_with_overwritable_defaults() {
 extract_config_with_overwritable_defaults 'daemonset'
 extract_config_with_overwritable_defaults 'deployment'
 
-
-
-
+# Document last synced version in the following line
+# last synced version: 0.8.26
+chart_version=$(helm show chart newrelic/nr-k8s-otel-collector | yq .version)
+# Determine the OS and set the sed -i command accordingly
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  function sed_inplace {
+  	sed -i '' "$@"
+  }
+else
+  function sed_inplace {
+    	sed -i'' "$@"
+  }
+fi
+sed_inplace -E "s/^# last synced version: .*/# last synced version: ${chart_version}/" "$0"


### PR DESCRIPTION
### Summary
- Related [PRs](https://github.com/newrelic/helm-charts/commits/master/charts/nr-k8s-otel-collector/Chart.yaml?since=2025-05-15&until=2025-06-20) for `0.8.14` through `0.8.26`. 
- Noteworthy changes for us
   - `0.8.23` got rid of the debugexporter, so we can remove the corresponding cleanup step from our sync script

edited-by: @kb-newrelic 