### PR TITLE
test: use nr-k8s-otel-collector for k8s nightly

### DIFF
--- a/distributions/nrdot-collector-host/test-spec.yaml
+++ b/distributions/nrdot-collector-host/test-spec.yaml
@@ -2,6 +2,9 @@ slow:
   testCaseSpecs:
     - host
 nightly:
+  collectorChart:
+    name: nr_backend
+    version: 0.1.0
   ec2:
     enabled: true
   testCaseSpecs:

--- a/distributions/nrdot-collector-k8s/test-spec.yaml
+++ b/distributions/nrdot-collector-k8s/test-spec.yaml
@@ -8,6 +8,9 @@ slow:
     - k8s
     - host
 nightly:
+  collectorChart:
+    name: newrelic/nr-k8s-otel-collector
+    version: 0.8.28
   ec2:
     enabled: false
   testCaseSpecs:

--- a/distributions/nrdot-collector-k8s/test-spec.yaml
+++ b/distributions/nrdot-collector-k8s/test-spec.yaml
@@ -14,4 +14,5 @@ nightly:
   ec2:
     enabled: false
   testCaseSpecs:
+    - k8s
     - host

--- a/test/e2e/util/spec/k8s.yaml
+++ b/test/e2e/util/spec/k8s.yaml
@@ -5,7 +5,7 @@ whereClause:
 
 # TODO: add more, just one example test case to ensure the overall setup works
 testCases:
-  host_receiver_cpu.utilization_user:
+  k8s_pod_cpu_usage:
     metric:
       name: k8s.pod.cpu.usage
     assertions:


### PR DESCRIPTION
### Summary
- Use nr-k8s-otel-collector helm chart for nightly tests of k8s distro
- Peer PR to [this one](https://github.com/newrelic/nrdot-collector-releases/pull/325) which addresses fast and slow tests