### PR TITLE
chore: release k8s distro

### DIFF
--- a/distributions/README.md
+++ b/distributions/README.md
@@ -78,7 +78,7 @@ If a distribution provides linux packages (refer to its README), you can follow 
 ##### DEB Installation
 ```bash
 export collector_distro="nrdot-collector-host"
-export collector_version="1.1.0"
+export collector_version="1.1.1"
 export collector_arch="amd64" # or arm64
 export license_key="YOUR_LICENSE_KEY"
 
@@ -91,7 +91,7 @@ sudo systemctl reload-or-restart "${collector_distro}.service"
 ### RPM Installation
 ```bash
 export collector_distro="nrdot-collector-host"
-export collector_version="1.1.0"
+export collector_version="1.1.1"
 export collector_arch="x86_64" # or arm64
 export license_key="YOUR_LICENSE_KEY"
 
@@ -105,7 +105,7 @@ sudo systemctl reload-or-restart "${collector_distro}.service"
 Archives contain the binary and the default configuration which is usually `config.yaml` unless the distro packages multiple defaults, e.g. `nrdot-collector-k8s`.
 ```bash
 export collector_distro="nrdot-collector-host"
-export collector_version="1.1.0"
+export collector_version="1.1.1"
 export collector_arch="amd64" # or arm64
 export license_key="YOUR_LICENSE_KEY"
 curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_${collector_version}_linux_${collector_arch}.tar.gz" --location --output collector.tar.gz

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/nrdot-collector-releases/nrdot-collector-host
   name: nrdot-collector-host
   description: NRDOT Collector Host
-  version: 1.1.0
+  version: 1.1.1
   output_path: ./_build
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.0

--- a/distributions/nrdot-collector-k8s/README.md
+++ b/distributions/nrdot-collector-k8s/README.md
@@ -3,7 +3,7 @@
 | Status    |                                                                                     |
 |-----------|-------------------------------------------------------------------------------------|
 | Distro    | `nrdot-collector-k8s`                                                               |
-| Stability | `preview`                                                                           |
+| Stability | `public`                                                                           |
 | Artifacts | [Docker images on DockerHub](https://hub.docker.com/r/newrelic/nrdot-collector-k8s) |
 
 A distribution of the NRDOT collector focused on gathering metrics in a kubernetes environment.

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/nrdot-collector-releases/nrdot-collector-k8s
   name: nrdot-collector-k8s
   description: NRDOT Collector k8s
-  version: 1.1.0
+  version: 1.1.1
   output_path: ./_build
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.0

--- a/scripts/bump-nrdot-version.sh
+++ b/scripts/bump-nrdot-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Simple script to bump versions for new release to document all places that need to be updated
 set -e
-old_version=2.0.0
+old_version=1.1.0
 new_version=1.1.1
 
 REPO_DIR="$( cd "$(dirname "$( dirname "${BASH_SOURCE[0]}" )")" &> /dev/null && pwd )"

--- a/scripts/bump-nrdot-version.sh
+++ b/scripts/bump-nrdot-version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Simple script to bump versions for new release to document all places that need to be updated
 set -e
-old_version=1.0.3
-new_version=1.1.0
+old_version=2.0.0
+new_version=1.1.1
 
 REPO_DIR="$( cd "$(dirname "$( dirname "${BASH_SOURCE[0]}" )")" &> /dev/null && pwd )"
 


### PR DESCRIPTION
### Summary
- Bump version to 1.1.1
- Label `nrdot-collector-k8s` as public