### PR TITLE
chore(deps): ensure dep chart version lockstep

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
       ],
       "matchStringsStrategy": "combination",
       "matchStrings": [
-        ".*newrelic/(?<depName>nr-k8s-otel-collector)\\s+version:\\s+(?<currentValue>[\\d\\.]+)",
+        ".*# renovatebot.*\\s*name:\\s+newrelic\/(?<depName>nr-k8s-otel-collector)\\s+version:\\s+&k8s_chart_version\\s+(?<currentValue>[\\d\\.]+)",
       ],
       "registryUrlTemplate": "https://helm-charts.newrelic.com",
       "datasourceTemplate": "helm",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
       ],
       "matchStringsStrategy": "combination",
       "matchStrings": [
-        ".*# renovatebot.*\\s*name:\\s+newrelic\/(?<depName>nr-k8s-otel-collector)\\s+version:\\s+&k8s_chart_version\\s+(?<currentValue>[\\d\\.]+)",
+        ".*# renovatebot.*\\s*name:\\s+newrelic\/(?<depName>nr-k8s-otel-collector)\\s+version:\\s+(?:&[\\w_]+\\s+)?(?<currentValue>[\\d\\.]+)",
       ],
       "registryUrlTemplate": "https://helm-charts.newrelic.com",
       "datasourceTemplate": "helm",

--- a/.github/workflows/lint-renovate-config.yaml
+++ b/.github/workflows/lint-renovate-config.yaml
@@ -18,3 +18,15 @@ jobs:
 
       - name: Test that the config is valid
         run: renovate-config-validator
+
+      - name: Test that k8s test-spec is matched
+        run: |
+          # info log shows what files and dep ach 'manager' matched
+          INFO_LOG=$(LOG_LEVEL=info renovate --platform=local)
+          # we currently expect exactly 1 file and 1 dep
+          if ! grep 'regex' <<< "${INFO_LOG}" | grep 'fileCount\": 1, \"depCount\": 1'; then
+            echo "renovate didn't match k8s test-spec"
+            DEBUG_LOG=$(LOG_LEVEL=debug renovate --platform=local)
+            echo "Debug log:\n${DEBUG_LOG}"
+            exit 1
+          fi

--- a/distributions/nrdot-collector-k8s/test-spec.yaml
+++ b/distributions/nrdot-collector-k8s/test-spec.yaml
@@ -8,15 +8,16 @@ fast:
   enabled: false
 slow:
   collectorChart:
+    # renovatebot (matched by regex - verify it still matches when modifying)
     name: newrelic/nr-k8s-otel-collector
-    version: 0.8.28
+    version: &k8s_chart_version 0.8.28
   testCaseSpecs:
     - k8s
     - host
 nightly:
   collectorChart:
     name: newrelic/nr-k8s-otel-collector
-    version: 0.8.31
+    version: *k8s_chart_version
   ec2:
     enabled: false
   testCaseSpecs:


### PR DESCRIPTION
### Summary
- Renovate doesn't match same regex twice per file (#334) but rather just the last one as far as I can tell, otherwise I would've expected a second PR by now.
- The best I could come up with to address this was to use yaml anchors instead. It also expresses more clearly that those versions are supposed to be the same
- Reverting it back to 0.8.28 to see if renovatebot works correctly