### PR TITLE
test: fail on unexpected warn logs

### DIFF
--- a/distributions/nrdot-collector-host/test-spec.yaml
+++ b/distributions/nrdot-collector-host/test-spec.yaml
@@ -17,3 +17,6 @@ nightly:
     enabled: true
   testCaseSpecs:
     - host
+expectedWarnLogs:
+  - 'host id not found in: /etc/machine-id or /var/lib/dbus/machine-id'
+  - 'No `root_path` config set when running in docker environment'

--- a/distributions/nrdot-collector-k8s/test-spec.yaml
+++ b/distributions/nrdot-collector-k8s/test-spec.yaml
@@ -22,3 +22,5 @@ nightly:
   testCaseSpecs:
     - k8s
     - host
+expectedWarnLogs:
+  - 'host id not found in: /etc/machine-id or /var/lib/dbus/machine-id'

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -51,3 +51,23 @@ spec:
                   fieldPath: spec.nodeName
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "host.name={{ .Values.collector.hostname }}-$(KUBE_NODE_NAME)"
+          volumeMounts:
+            - name: dummy-logs
+              mountPath: /var/log
+        - name: log-churner
+          image: busybox
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - |
+              file='/var/log/yum.log'
+              while true; do
+                sleep 5;
+                echo "$(date)" > ${file};
+              done
+          volumeMounts:
+            - name: dummy-logs
+              mountPath: /var/log
+      volumes:
+        - name: dummy-logs
+          emptyDir: {}
+

--- a/test/e2e/util/spec/test_spec.go
+++ b/test/e2e/util/spec/test_spec.go
@@ -13,8 +13,9 @@ type CollectorChart struct {
 	Version string `yaml:"version"`
 }
 type TestSpec struct {
-	WhereClause map[string]RenderableTemplate `yaml:"whereClause"`
-	Fast        struct {
+	WhereClause      map[string]RenderableTemplate `yaml:"whereClause"`
+	ExpectedWarnLogs []string                      `yaml:"expectedWarnLogs"`
+	Fast             struct {
 		CollectorChart CollectorChart `yaml:"collectorChart"`
 		Enabled        bool           `yaml:"enabled"`
 	} `yaml:"fast"`


### PR DESCRIPTION
### Summary
- Add test to fail on unexpected warn logs. Certain warn logs are expected due to test setup and can be ignored by an entry in the test spec
- `nr_backend` chart used by host distro: Added a log file that gets written to by a busybox to avoid the filelogreceiver writing a warning that it doesn't have any file to read. 