### PR TITLE
chore: cleanup old team references

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -31,7 +31,6 @@ jobs:
       nr_backend_url: ${{ secrets.NR_STAGING_BACKEND_URL }}
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }}
-      nr_api_base_url: ${{ secrets.NR_STAGING_API_BASE_URL }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
 
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ dist/
 .vscode
 ci/terraform/terraform.backend.tf
 inventory
-ci/terraform/caos.auto.tfvars
 # Local .terraform directories
 **/.terraform/
 # .tfstate files

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -227,7 +227,7 @@ func Package(dist string) config.NFPM {
 		Formats:     []string{"deb", "rpm"},
 		License:     "Apache 2.0",
 		Description: fmt.Sprintf("NRDOT Collector - %s", dist),
-		Maintainer:  "New Relic <caos-team@newrelic.com>",
+		Maintainer:  "New Relic <otelcomm-team@newrelic.com>",
 		Overrides: map[string]config.NFPMOverridables{
 			"rpm": {
 				Dependencies: []string{"/bin/sh"},

--- a/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
@@ -67,7 +67,7 @@ nfpms:
     formats:
       - deb
       - rpm
-    maintainer: New Relic <caos-team@newrelic.com>
+    maintainer: New Relic <otelcomm-team@newrelic.com>
     description: NRDOT Collector - nrdot-collector-host
     license: Apache 2.0
 snapshot:

--- a/distributions/nrdot-collector-host/.goreleaser.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser.yaml
@@ -67,7 +67,7 @@ nfpms:
     formats:
       - deb
       - rpm
-    maintainer: New Relic <caos-team@newrelic.com>
+    maintainer: New Relic <otelcomm-team@newrelic.com>
     description: NRDOT Collector - nrdot-collector-host
     license: Apache 2.0
 snapshot:


### PR DESCRIPTION
### Summary
- Replace references to CAOS team with OTELCOMM
- Remove secret nr_api_base_url which is no longer used by ci-base.yaml