### PR TITLE
test: fix nightly

### DIFF
--- a/test/charts/nr_backend/Chart.yaml
+++ b/test/charts/nr_backend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: nrdot-nr-backend
+description: A Helm chart for deploying an nrdot collector as a DaemonSet writing to New Relic
+version: 0.2.0
+appVersion: "1.0"

--- a/test/charts/nr_backend/templates/collector-secrets.yaml
+++ b/test/charts/nr_backend/templates/collector-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: collector-secrets
+type: Opaque
+data:
+  backendUrl: {{ .Values.secrets.nrBackendUrl | b64enc }}
+  nrIngestKey: {{ .Values.secrets.nrIngestKey | b64enc }}

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: &app nrdot-collector-daemonset
+  labels:
+    app: *app
+spec:
+  selector:
+    matchLabels:
+      app: *app
+  template:
+    metadata:
+      labels:
+        app: *app
+    spec:
+      containers:
+        - name: *app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - name: health
+              containerPort: 13133
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: collector-secrets
+                  key: backendUrl
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: collector-secrets
+                  key: nrIngestKey
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "host.name={{ .Values.collector.hostname }}-$(KUBE_NODE_NAME)"

--- a/test/charts/nr_backend/values.yaml
+++ b/test/charts/nr_backend/values.yaml
@@ -1,0 +1,14 @@
+image:
+  repository: newrelic/nrdot-collector-host
+  tag: latest
+  # Avoid accidentally pulling remote images in CI
+  pullPolicy: Never
+
+secrets:
+  nrBackendUrl: PLACEHOLDER
+  nrIngestKey: PLACEHOLDER
+
+collector:
+  hostname: nrdot-collector-default-hostname
+
+clusterName: default-cluster-name

--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -1,5 +1,5 @@
 locals {
-  test_spec                                       = yamldecode(file("${path.module}/../../../distributions/${var.distro}/spec-nightly.yaml"))
+  test_spec                                       = yamldecode(file("${path.module}/../../../distributions/${var.distro}/test/spec-nightly.yaml"))
   ec2_enabled                                     = local.test_spec.nightly.ec2.enabled
   chart_name                                      = local.test_spec.nightly.collectorChart.name
   chart_version                                   = local.test_spec.nightly.collectorChart.version


### PR DESCRIPTION
### Summary
- nr-backend chart was accidentally removed and broke nightly. This PR reintroduces it until we had time to migrate nightly to using the same k8s resource setup as our 'normal' e2e tests which no longer requires the helm chart.

### Test
- In order to validate the changes I ran nightly with this branch and it passed: https://github.com/newrelic/nrdot-collector-releases/actions/runs/16754753303