### PR TITLE
chore: Add missing ec2 nightly deploy

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -138,6 +138,7 @@ jobs:
     strategy:
       matrix:
         distribution:
+          - nrdot-collector
           - nrdot-collector-host
           - nrdot-collector-k8s
     concurrency:


### PR DESCRIPTION
Missing deploy step for core distro