### PR TITLE
chore: Address cancelled deploy step

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -6,6 +6,10 @@ on:
     # Scheduled to run in the morning (PT) on every day-of-week from Monday through Friday.
     - cron: '0 15 * * 1-5'
 
+concurrency:
+  group: ci-nightly
+  cancel-in-progress: false
+
 env:
   REGISTRY: '${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com'
 
@@ -141,9 +145,6 @@ jobs:
           - nrdot-collector
           - nrdot-collector-host
           - nrdot-collector-k8s
-    concurrency:
-      # concurrency limit of 1 b/c failed tf job cancelling each other causes tf state and locks to corrupt
-      group: deploy-nightly-terraform
     with:
       branch: ${{ github.ref }}
       tf_work_subdir: nightly


### PR DESCRIPTION
We were seeing cancelled steps due to the group logic.  I've updated the group to be dynamic based on the distribution.  Since we use separate workspaces they should each get their own tf lock.

Here is the test run for nightly: https://github.com/newrelic/nrdot-collector-releases/actions/runs/16922013993