### PR TITLE
feat(internal): expose trace sampling as env var

### DIFF
--- a/examples/internal-telemetry-config.yaml
+++ b/examples/internal-telemetry-config.yaml
@@ -1,15 +1,19 @@
 ##### Example configuration for internal telemetry
 # This configuration is intended to be used in conjunction with a configuration of components and pipelines. The
 # collector supports config merging on startup.
+##### Requirements
+# - nrdot-collector (any distro) >= 1.3.0 or collector core version >= v1.35.0 / v0.129.0
 ##### Configuration via environment variables
-# For valid values, see: https://opentelemetry.io/docs/collector/internal-telemetry/
+# For official documentation, see: https://opentelemetry.io/docs/collector/internal-telemetry/
 ## Required
 # - INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY
 ## Optional
-# - INTERNAL_TELEMETRY_SERVICE_NAME: determines entity name in New Relic
-# - INTERNAL_TELEMETRY_OTLP_ENDPOINT: defaults to https://otlp.nr-data.net (https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
-# - INTERNAL_TELEMETRY_METRICS_LEVEL
-# - INTERNAL_TELEMETRY_LOG_LEVEL
+# - INTERNAL_TELEMETRY_SERVICE_NAME: defaults to 'otel-collector', determines entity name in New Relic
+# - INTERNAL_TELEMETRY_OTLP_ENDPOINT: defaults to 'https://otlp.nr-data.net', see https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/ and https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp-troubleshooting/
+# - INTERNAL_TELEMETRY_METRICS_LEVEL: defaults to 'detailed', other values are 'normal', 'basic', 'none'
+# - INTERNAL_TELEMETRY_LOG_LEVEL: defaults to INFO, other values are DEBUG, WARN, ERROR
+# - INTERNAL_TELEMETRY_TRACE_LEVEL: defaults to 'basic', other value is 'none'
+# - INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO: defaults to 1.0, i.e. all spans get sampled, use float <1, e.g. 0.1 for 10% sampling
 service:
   telemetry:
     metrics:
@@ -19,12 +23,21 @@ service:
             exporter:
               otlp:
                 protocol: http/protobuf
-                # https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp-troubleshooting/
                 endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
                 headers:
-                  api-key: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
     logs:
       level: "${env:INTERNAL_TELEMETRY_LOG_LEVEL:-INFO}"
+      # default sampling config for reference to simplify overwrites even if not exposed via env var, e.g. --config=yaml:service::telemetry::logs::sampling::enabled::false
+      sampling:
+        enabled: true
+        # The interval in seconds that the logger applies to each sampling.
+        tick: 10s
+        # The number of messages logged at the start of each sampling::tick
+        initial: 10
+        # Sets the sampling policy for subsequent messages after sampling::initial messages are logged. When sampling::thereafter is set to N, every Nth message is logged and all others are dropped. If N is zero, the logger drops all messages after sampling::initial messages are logged.
+        thereafter: 100
       processors:
         - batch:
             exporter:
@@ -32,8 +45,15 @@ service:
                 protocol: http/protobuf
                 endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
                 headers:
-                  api-key: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
     traces:
+      level: "${env:INTERNAL_TELEMETRY_TRACE_LEVEL:-basic}"
+      sampler:
+        parent_based:
+          root:
+            trace_id_ratio_based:
+              ratio: ${env:INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO:-1.0}
       processors:
         - batch:
             exporter:
@@ -41,7 +61,8 @@ service:
                 protocol: http/protobuf
                 endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
                 headers:
-                  api-key: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
     resource:
-      newrelic.collector_telemetry.version: 0.1.0
+      newrelic.collector_telemetry.version: 0.2.0
       service.name: "${env:INTERNAL_TELEMETRY_SERVICE_NAME:-otel-collector}"


### PR DESCRIPTION
### Summary
- Document default and possible values for all env vars in the internal telemetry config
- Populate `logs::sampling` section [with defaults](https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs) to make it clear that logs are sampled by default with a time window-based algorithm
- Add `INTERNAL_TELEMETRY_TRACE_LEVEL` and `INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO` to configure tracing
   - Sampler was only [recently added](https://github.com/open-telemetry/opentelemetry-collector/commit/83102decdfb162a3b2cbd029d521a46a1431f873) to the collector's internal telemetry config and requires collector core version [>= v1.35.0/v0.129.0](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#v1350v01290)
   - This required migrating `otlp::headers` sections from config schema [v0.2.0](https://github.com/open-telemetry/opentelemetry-collector/blob/77e2afc13defa382e2ac0f6dc7013754817f00b7/service/telemetry/internal/migration/v0.2.0.go) to [v0.3.0](https://github.com/open-telemetry/opentelemetry-collector/blob/77e2afc13defa382e2ac0f6dc7013754817f00b7/service/telemetry/internal/migration/v0.3.0.go) as the [fallback parsing](https://github.com/open-telemetry/opentelemetry-collector/blob/77e2afc13defa382e2ac0f6dc7013754817f00b7/service/telemetry/internal/migration/v0.3.0.go#L31-L44) failed with the new `sampler` section