### PR TITLE
test: use testKey instead of host.name for nightly

### DIFF
--- a/distributions/nrdot-collector-host/test/spec-nightly.yaml
+++ b/distributions/nrdot-collector-host/test/spec-nightly.yaml
@@ -1,7 +1,6 @@
 nightly:
   collectorChart:
     name: nr_backend
-    version: 0.1.0
   ec2:
     enabled: true
   testCaseSpecs:

--- a/distributions/nrdot-collector/test/spec-nightly.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly.yaml
@@ -1,7 +1,6 @@
 nightly:
   collectorChart:
     name: nr_backend
-    version: 0.1.0
   ec2:
     enabled: true
   testCaseSpecs:

--- a/test/charts/nr_backend/Chart.yaml
+++ b/test/charts/nr_backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: nrdot-nr-backend
 description: A Helm chart for deploying an nrdot collector as a DaemonSet writing to New Relic
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0"

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -37,4 +37,4 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "host.name={{ .Values.collector.hostname }}-$(KUBE_NODE_NAME)"
+              value: "testKey={{ .Values.testKey }}-$(KUBE_NODE_NAME)"

--- a/test/charts/nr_backend/values.yaml
+++ b/test/charts/nr_backend/values.yaml
@@ -8,7 +8,6 @@ secrets:
   nrBackendUrl: PLACEHOLDER
   nrIngestKey: PLACEHOLDER
 
-collector:
-  hostname: nrdot-collector-default-hostname
+testKey: testKey-default-value
 
 clusterName: default-cluster-name

--- a/test/e2e/nightly/nightly_collector_nr_backend_test.go
+++ b/test/e2e/nightly/nightly_collector_nr_backend_test.go
@@ -12,19 +12,19 @@ import (
 )
 
 var ec2Ubuntu22 = spec.NightlySystemUnderTest{
-	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu22_04"),
+	TestKeyPattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu22_04"),
 	SkipIf: func(testSpec *spec.TestSpec) bool {
 		return !testSpec.Nightly.EC2.Enabled
 	},
 }
 var ec2Ubuntu24 = spec.NightlySystemUnderTest{
-	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
+	TestKeyPattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
 	SkipIf: func(testSpec *spec.TestSpec) bool {
 		return !testSpec.Nightly.EC2.Enabled
 	},
 }
 var k8sNode = spec.NightlySystemUnderTest{
-	HostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),
+	TestKeyPattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),
 }
 
 func TestNightlyCollectorWithNrBackend(t *testing.T) {
@@ -35,12 +35,12 @@ func TestNightlyCollectorWithNrBackend(t *testing.T) {
 
 	for _, sut := range []spec.NightlySystemUnderTest{ec2Ubuntu22, ec2Ubuntu24, k8sNode} {
 		if sut.SkipIf != nil && sut.SkipIf(testSpec) {
-			t.Logf("Skipping nightly system-under-test: %s", sut.HostNamePattern)
+			t.Logf("Skipping nightly system-under-test: %s", sut.TestKeyPattern)
 			continue
 		}
 		testEnvironment := map[string]string{
 			"clusterName": envutil.GetK8sContextName(),
-			"hostName":    sut.HostNamePattern,
+			"testKey":     sut.TestKeyPattern,
 		}
 		for _, testCaseSpecName := range testSpec.Nightly.TestCaseSpecs {
 			testCaseSpec := spec.LoadTestCaseSpec(testCaseSpecName)
@@ -52,7 +52,7 @@ func TestNightlyCollectorWithNrBackend(t *testing.T) {
 
 			whereClause := testCaseSpec.RenderWhereClause(testEnvironment)
 			for caseName, testCase := range testCaseSpec.GetTestCasesWithout(sut.ExcludedMetrics) {
-				t.Run(fmt.Sprintf("%s/%s/%s", sut.HostNamePattern, testCaseSpecName, caseName), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%s/%s/%s", sut.TestKeyPattern, testCaseSpecName, caseName), func(t *testing.T) {
 					t.Parallel()
 					assertionFactory := assert.NewNrMetricAssertionFactory(
 						whereClause,

--- a/test/e2e/util/spec/host.yaml
+++ b/test/e2e/util/spec/host.yaml
@@ -1,7 +1,7 @@
 whereClause:
-  template: "WHERE host.name like '{{ .hostName }}'"
+  template: "WHERE testKey like '{{ .testKey }}'"
   vars:
-    - hostName
+    - testKey
 
 testCases:
   host_receiver_cpu.utilization_user:

--- a/test/e2e/util/spec/nightly.go
+++ b/test/e2e/util/spec/nightly.go
@@ -1,7 +1,7 @@
 package spec
 
 type NightlySystemUnderTest struct {
-	HostNamePattern string
+	TestKeyPattern  string
 	ExcludedMetrics []string
 	SkipIf          func(testSpec *TestSpec) bool
 }

--- a/test/e2e/util/spec/test_case_spec_test.go
+++ b/test/e2e/util/spec/test_case_spec_test.go
@@ -7,9 +7,9 @@ import (
 func TestRenderWhereClause(t *testing.T) {
 	testCaseSpec := LoadTestCaseSpec("host")
 	actual := testCaseSpec.RenderWhereClause(map[string]string{
-		"hostName": "nrdot-collector-host-foobar",
+		"testKey": "nrdot-collector-host-foobar",
 	})
-	if actual != "WHERE host.name like 'nrdot-collector-host-foobar'" {
+	if actual != "WHERE testKey like 'nrdot-collector-host-foobar'" {
 		t.Fatalf("unexpected where clause: %s", actual)
 	}
 }

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -139,7 +139,7 @@ resource "aws_instance" "ubuntu" {
               ################################################
               echo 'Configuring Collector'
               echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/${var.collector_distro}/${var.collector_distro}.conf
-              echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname_prefix}-${local.instance_config[count.index].hostname_suffix}'" >> /etc/${var.collector_distro}/${var.collector_distro}.conf
+              echo "OTEL_RESOURCE_ATTRIBUTES='testKey=${local.collector_reported_hostname_prefix}-${local.instance_config[count.index].hostname_suffix}'" >> /etc/${var.collector_distro}/${var.collector_distro}.conf
               systemctl reload-or-restart ${var.collector_distro}.service
               EOF
 }

--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -19,10 +19,9 @@ data "aws_ecr_repository" "ecr_repo" {
 }
 
 resource "helm_release" "ci_e2e_nightly_nr_backend" {
-  count   = local.chart_name == "nr_backend" ? 1 : 0
-  name    = "nightly-nr-backend-${var.distro}"
-  chart   = "../../charts/nr_backend"
-  version = local.chart_version
+  count = local.chart_name == "nr_backend" ? 1 : 0
+  name  = "nightly-nr-backend-${var.distro}"
+  chart = "../../charts/nr_backend"
 
   create_namespace  = true
   namespace         = local.k8s_namespace
@@ -54,7 +53,7 @@ resource "helm_release" "ci_e2e_nightly_nr_backend" {
   }
 
   set {
-    name  = "collector.hostname"
+    name  = "testKey"
     value = "${var.test_environment}-${random_string.deploy_id.result}-${var.distro}-k8s_node"
   }
 


### PR DESCRIPTION
### Summary
- Migrates nightly to use `testKey` resource attribute to identify telemetry at query time. This is both to iterate towards using `newrelic/newrelic-integration-e2e-action` eventually but also to remove the overwrite of `host.name` in our nightly tests so that we can better verify the behavior of our resourcedetectionprocessor configs.