### PR TITLE
ci: pin goreleaser at last working version

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -108,7 +108,7 @@ jobs:
           REGISTRY: "${{ secrets.registry }}"
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: '2.11.2'
           args: ${{ env.goreleaser_args }}
           workdir: distributions/${{ inputs.distribution }}
 

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -119,7 +119,7 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: '2.11.2'
           args: --skip=announce,validate --clean --timeout 2h --config .goreleaser-nightly.yaml
           workdir: distributions/${{ matrix.distribution }}
       - name: Extract Docker Manifest SHA

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: '2.11.2'
           args: --clean --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,6 +111,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: '2.11.2'
           args: --clean --skip=announce --timeout 2h
           workdir: distributions/${{ matrix.distribution }}


### PR DESCRIPTION
### Summary
- [Nightly failed](https://github.com/newrelic/nrdot-collector-releases/actions/runs/17437682159/job/49513819884#step:13:24) and the only thing that seems to have changed is the goreleaser verison (2.11.2 -> 2.12.0). As the [new version has no obvious breaking change that would affect us](https://goreleaser.com/blog/goreleaser-v2.12/#attestations), this PR pins the last known working version in the hope to fix the build until we have time to investigate further.