### PR TITLE
feat: add newrelic.service.type to internal telemetry config

### DIFF
--- a/distributions/nrdot-collector-host/test/spec-local.yaml
+++ b/distributions/nrdot-collector-host/test/spec-local.yaml
@@ -190,6 +190,19 @@ scenarios:
         - source: "internal-expected-metrics.yaml"
       # Tests for existence of signal + specific attributes
       nrqls:
+        # Resource attributes (any signal would work)
+        - query: FROM Log SELECT filter(count(*), service.name is not null) as logs_service_name
+          expected_results:
+            - key: logs_service_name
+              lowerBoundedValue: 1
+        - query: FROM Log SELECT filter(count(*), newrelic.collector_telemetry.version is not null) as logs_telemetry_version
+          expected_results:
+            - key: logs_telemetry_version
+              lowerBoundedValue: 1
+        - query: FROM Log SELECT filter(count(*), newrelic.service.type='otel_collector') as logs_service_type
+          expected_results:
+            - key: logs_service_type
+              lowerBoundedValue: 1
         # Logs
         - query: FROM Log SELECT count(*) as logs_all
           expected_results:

--- a/distributions/nrdot-collector/test/spec-local.yaml
+++ b/distributions/nrdot-collector/test/spec-local.yaml
@@ -190,6 +190,19 @@ scenarios:
         - source: "internal-expected-metrics.yaml"
       # Tests for existence of signal + specific attributes
       nrqls:
+        # Resource attributes (any signal would work)
+        - query: FROM Log SELECT filter(count(*), service.name is not null) as logs_service_name
+          expected_results:
+            - key: logs_service_name
+              lowerBoundedValue: 1
+        - query: FROM Log SELECT filter(count(*), newrelic.collector_telemetry.version is not null) as logs_telemetry_version
+          expected_results:
+            - key: logs_telemetry_version
+              lowerBoundedValue: 1
+        - query: FROM Log SELECT filter(count(*), newrelic.service.type='otel_collector') as logs_service_type
+          expected_results:
+              - key: logs_service_type
+                lowerBoundedValue: 1
         # Logs
         - query: FROM Log SELECT count(*) as logs_all
           expected_results:

--- a/examples/internal-telemetry-config.yaml
+++ b/examples/internal-telemetry-config.yaml
@@ -64,5 +64,6 @@ service:
                   - name: api-key
                     value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
     resource:
-      newrelic.collector_telemetry.version: 0.2.0
+      newrelic.collector_telemetry.version: 0.3.0
+      newrelic.service.type: otel_collector
       service.name: "${env:INTERNAL_TELEMETRY_SERVICE_NAME:-otel-collector}"


### PR DESCRIPTION
### Summary
- Add resource attribute `newrelic.service.type: otel_collector` to the internal example config to [tag collectors getting synthesized as ext-service](https://github.com/newrelic/entity-definitions/blob/main/entity-types/ext-service/definition.yml#L95-L96)