### PR TITLE
test: fallback to null if chart version not defined

### DIFF
--- a/test/terraform/nightly/main.tf
+++ b/test/terraform/nightly/main.tf
@@ -2,7 +2,7 @@ locals {
   test_spec                                       = yamldecode(file("${path.module}/../../../distributions/${var.distro}/test/spec-nightly.yaml"))
   ec2_enabled                                     = local.test_spec.nightly.ec2.enabled
   chart_name                                      = local.test_spec.nightly.collectorChart.name
-  chart_version                                   = local.test_spec.nightly.collectorChart.version
+  chart_version                                   = try(local.test_spec.nightly.collectorChart.version, null)
   releases_bucket_name                            = "nr-releases"
   required_permissions_boundary_arn_for_new_roles = "arn:aws:iam::${var.aws_account_id}:policy/resource-provisioner-boundary"
   k8s_namespace                                   = "nightly-${var.distro}"


### PR DESCRIPTION
### Summary
- Fixes #378 which doesn't account for terraform erroring instead of using `null` for an undefined field of an object.