### PR TITLE
Feat: Adding metrics generation processor from opentelemetry-collector-contrib

### DIFF
--- a/distributions/nrdot-collector-k8s/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-k8s/THIRD_PARTY_NOTICES.md
@@ -68,6 +68,14 @@ Distributed under the following license(s):
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -19,6 +19,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.135.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.135.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.135.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.135.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.135.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.135.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.135.0


### PR DESCRIPTION
This is a very useful processor that allows us to create custom metrics on the client (Collector) side instead of from within ingest/ NRQL. 

The ability to do some simple arithmatic from the collector prevents us from having to either: 
* Create a new ingest pipeline to scrape and combine metrics upon ingest
* Create overly complicated queries. 

Take for example the following query. 
``` SQL
FROM(
  FROM(
    FROM Metric 
    SELECT latest(kube_pod_container_resource_requests) AS containerRequest
    WHERE resource = 'cpu' AND container_phase != 'terminated'
    FACET k8s.container.name, k8s.pod.name, k8s.node.name, k8s.namespace.name LIMIT MAX
  )
  SELECT sum(containerRequest) AS totalRequests FACET k8s.node.name LIMIT MAX
) 
JOIN (
  FROM Metric
  SELECT latest(kube_node_status_allocatable) AS totalAllocatable
  WHERE resource = 'cpu' 
  FACET k8s.node.name LIMIT MAX
) ON k8s.node.name
SELECT sum(totalRequests)/ sum(totalAllocatable) * 100
```
This query is simply getting the average CPU utilization as a percentage across all of a customer's nodes.
Yet it has to be so monstrous because we have to be very careful when doing math on metrics to insure we are dividing the cpu usage and cpu capacity from the same nodes. 

From our experimentation with the metrics generation processor we've been able to reduce this query down to this. 
``` SQL
FROM Metric SELECT average(node.cpu.usage.percentage) 
```