### PR TITLE
feat: windows installer

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -169,15 +169,15 @@ jobs:
         run: |
           # Determine base skip flags and snapshot mode based on publish input
           if [ "${{ inputs.publish }}" = "true" ]; then
-            BASE_SKIP="--skip=announce,validate"
+            BASE_SKIP="--skip=announce,validate,msi"
             SNAPSHOT_FLAG=""  # No --snapshot for publishing builds to get proper versions
           else
-            BASE_SKIP="--skip=publish,validate"
+            BASE_SKIP="--skip=publish,validate,msi"
             SNAPSHOT_FLAG="--snapshot"  # Use --snapshot for dev builds to get SNAPSHOT versions
           fi
 
           if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
-            BASE_SKIP="--skip=publish,validate,sign"
+            BASE_SKIP="--skip=publish,validate,sign,msi"
           fi
 
           GORELEASER_CONFIG="${{ format('.goreleaser{0}.yaml', inputs.fips && '-fips' || '') }}"
@@ -190,6 +190,7 @@ jobs:
         run: |
           BINARY_HASH="${{ hashFiles(
             format('distributions/{0}/.goreleaser*.yaml', inputs.distribution),
+            format('distributions/{0}/windows/*', inputs.distribution),
             format('distributions/{0}/_build*/*', inputs.distribution)
           ) }}"
           ARGS_HASH=$(echo "${{ env.goreleaser_args }}" | sha256sum | cut -d' ' -f1)
@@ -227,7 +228,7 @@ jobs:
           REGISTRY: "${{ env.registry }}"
           GORELEASER_KEY: ${{ secrets.goreleaser_key }}
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: "2.11.2"
           args: ${{ env.goreleaser_args }}
           workdir: distributions/${{ inputs.distribution }}
@@ -404,7 +405,6 @@ jobs:
           echo "✅ Docker image SHA: ${docker_manifest_sha}"
           echo -n "${docker_manifest_sha}" > docker_manifest_sha
 
-
           # Set output names
           if [[ "${{ inputs.fips }}" == "true" ]]; then
             artifact_name="goreleaser_output_${{ inputs.distribution }}-fips_${{ github.sha }}"
@@ -421,7 +421,6 @@ jobs:
           echo "=== Artifact Structure [$artifact_name] ==="
           tree dist/ || find dist -type d | sort
 
-
       - name: Upload Artifacts
         if: ${{ !env.ACT && inputs.publish }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -430,4 +429,3 @@ jobs:
           path: |
             docker_manifest_sha
             dist
-

--- a/.github/workflows/ci-snapshot-cli.yaml
+++ b/.github/workflows/ci-snapshot-cli.yaml
@@ -54,7 +54,7 @@ jobs:
         id: goreleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: "~> v2"
           args: --snapshot --clean
           workdir: cmd/nrdot-collector-builder

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -142,6 +142,13 @@ jobs:
 
       - name: Install MSI
         run: |
+          # Set nrdot config environment variables.
+          # Do not need to broadcast WM_SETTINGCHANGE for local env
+          $env:NEW_RELIC_LICENSE_KEY = "${{ secrets.nr_ingest_key }}"
+          $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.nr-data.net"
+          $env:OTEL_RESOURCE_ATTRIBUTES = "testKey=$env:SCENARIO_TAG"
+
+          # Install MSI
           $log_path = Join-Path $env:TEMP "msi-install.log"
           $msi_args = @(
               '/i',
@@ -150,24 +157,9 @@ jobs:
               '/l*',
               $log_path
           )
-
-          # Validate install fails when no license key provided
           $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
-          if ($process.ExitCode -eq 0) {
-            Write-Host "❌ MSI installation allowed to proceed without ingest key"
-            exit 1
-          }
-          if (Test-Path $log_path) {
-            Remove-Item $log_path -Force
-          }
 
-          # Validate successful install on license key provided
-          $msi_args += @(
-            'NEW_RELIC_LICENSE_KEY="${{ secrets.nr_ingest_key }}"',
-            'OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.nr-data.net"',
-            "OTEL_RESOURCE_ATTRIBUTES=`"testKey=$env:SCENARIO_TAG`""
-          )
-          $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
+          # Validate install successful
           Write-Host '`nInstallation Log (Last 200 lines):'
           Get-Content $log_path | Select-Object -Last 200
           if ($process.ExitCode -ne 0) {
@@ -180,12 +172,13 @@ jobs:
             exit $process.ExitCode
           }
 
-          # Validate environment variables in registry
-          $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
-          foreach ($var in $env_vars) {
-            Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var | Out-Null
-            Write-Host "✅ $var found in environment registry"
-          }
+          # No registry right now
+          # # Validate environment variables in registry
+          # $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
+          # foreach ($var in $env_vars) {
+          #   Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var | Out-Null
+          #   Write-Host "✅ $var found in environment registry"
+          # }
 
           Write-Host "⏳ Waiting 30 seconds for collector to spool up"
           Start-Sleep -Seconds 30

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,247 @@
+name: 🧩 CI Windows
+
+on:
+  workflow_call:
+    inputs:
+      distribution:
+        required: true
+        type: string
+    secrets:
+      goreleaser_key:
+        required: true
+      nr_account_id:
+        required: true
+      nr_api_key:
+        required: true
+      nr_ingest_key:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      msi_artifact_name: ${{ steps.find-msi.outputs.msi_artifact_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for tag metadata
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "~1.26"
+          check-latest: true
+
+      - name: Tidy go.mod files
+        run: go mod tidy
+
+      - name: Ensure goreleaser up to date
+        run: make check
+
+      - name: Generate sources
+        if: steps.cache-sources.outputs.cache-hit != 'true'
+        run: make ci DISTRIBUTIONS=${{ inputs.distribution }}
+
+      - name: Setup wixl # Required to build MSI
+        if: inputs.publish || steps.cache-goreleaser.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wixl
+
+      - name: Generate binary cache key
+        id: generate_binary_key
+        run: |
+          BINARY_HASH="${{ hashFiles(
+            format('distributions/{0}/.goreleaser*.yaml', inputs.distribution),
+            format('distributions/{0}/windows/*', inputs.distribution),
+            format('distributions/{0}/manifest.yaml/*', inputs.distribution)
+          ) }}"
+          echo binary_key=goreleaser-build-${{ inputs.distribution }}-${BINARY_HASH}-windows >> $GITHUB_OUTPUT
+
+      - name: Cache goreleaser build
+        id: cache-goreleaser
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            distributions/${{ inputs.distribution }}/dist
+          key: ${{ steps.generate_binary_key.outputs.binary_key }}
+
+      - name: Build binaries & packages with GoReleaser
+        if: steps.cache-goreleaser.outputs.cache-hit != 'true'
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GORELEASER_KEY: ${{ secrets.goreleaser_key }}
+          GOOS: windows
+          GOARCH: amd64
+        with:
+          distribution: goreleaser-pro
+          version: "2.11.2"
+          args: "--single-target --snapshot --clean --skip=publish,validate,sign,archive --timeout 2h --config .goreleaser.yaml"
+          workdir: distributions/${{ inputs.distribution }}
+
+      - name: Skip GoReleaser build (cached)
+        if: steps.cache-goreleaser.outputs.cache-hit == 'true'
+        run: echo "✅ GoReleaser build skipped - using cached binaries"
+
+      - name: Find MSI
+        id: find-msi
+        run: |
+          msi_artifact_name=${{ inputs.distribution }}_msi_${{ github.sha }}
+          msi_path="$(find distributions/${{ inputs.distribution }}/dist -name "*.msi" -type f)"
+          if [ ! -f "$msi_path" ]; then
+            echo "❌ Error: .msi not found at $msi_path"
+            exit 1
+          fi
+          echo "msi_path=$msi_path" >> $GITHUB_OUTPUT
+          echo "msi_artifact_name=$msi_artifact_name" >> $GITHUB_OUTPUT
+
+      - name: Upload MSI Artifact
+        id: upload-msi
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.find-msi.outputs.msi_artifact_name }}
+          path: ${{ steps.find-msi.outputs.msi_path }}
+          retention-days: 1
+
+  validate:
+    runs-on: windows-latest
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for tag metadata
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.msi_artifact_name }}
+          path: ./msi
+
+      - name: Generate e2e scenario tag
+        shell: bash
+        run: |
+          RANDOM_SUFFIX=$(echo $RANDOM$RANDOM | md5sum | cut -c1-7)
+          echo "SCENARIO_TAG=e2e-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
+
+      - name: Find MSI file
+        id: find-msi-file
+        run: |
+          $msi_path = Get-ChildItem -Path ./msi -Filter "*.msi" -Recurse | Select-Object -First 1 | Select-Object -ExpandProperty FullName
+          if (-not $msi_path) {
+            Write-Error "❌ No MSI file found from artifact"
+            exit 1
+          }
+          Write-Host "✅ Found MSI: $msi_path"
+          "msi_path=$msi_path" >> $env:GITHUB_ENV
+
+      - name: Install MSI
+        run: |
+          $log_path = Join-Path $env:TEMP "msi-install.log"
+          $msi_args = @(
+              '/i',
+              $env:msi_path,
+              '/qn',
+              '/l*',
+              $log_path
+          )
+
+          # Validate install fails when no license key provided
+          $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
+          if ($process.ExitCode -eq 0) {
+            Write-Host "❌ MSI installation allowed to proceed without ingest key"
+            exit 1
+          }
+          if (Test-Path $log_path) {
+            Remove-Item $log_path -Force
+          }
+
+          # Validate successful install on license key provided
+          $msi_args += @(
+            'NEW_RELIC_LICENSE_KEY="${{ secrets.nr_ingest_key }}"',
+            'OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.nr-data.net"',
+            "OTEL_RESOURCE_ATTRIBUTES=`"testKey=$env:SCENARIO_TAG`""
+          )
+          $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
+          Write-Host '`nInstallation Log (Last 200 lines):'
+          Get-Content $log_path | Select-Object -Last 200
+          if ($process.ExitCode -ne 0) {
+            Write-Host "❌ MSI installation failed with exit code $($process.ExitCode)"
+            if (Test-Path $log_path) {
+              Write-Host '`nInstallation Log - Errors and Warnings:'
+              Get-Content $log_path | Select-String -Pattern 'error|warning|failed|exception|fatal' -Context 2,2
+              Write-Host ''
+            }
+            exit $process.ExitCode
+          }
+
+          # Validate environment variables in registry
+          $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
+          foreach ($var in $env_vars) {
+            Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var | Out-Null
+            Write-Host "✅ $var found in environment registry"
+          }
+
+          Write-Host "⏳ Waiting 30 seconds for collector to spool up"
+          Start-Sleep -Seconds 30
+          
+          # Dump collector logs
+          Write-Host "`nCollector logs from Windows Event Log:"
+          Get-WinEvent -LogName Application -MaxEvents 100 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -eq "${{ inputs.distribution }}" } | Select-Object -ExpandProperty Message
+
+          # Check if service is running
+          $service = Get-Service -Name "${{ inputs.distribution }}"
+          if ($service -and $service.Status -eq 'Running') {
+            Write-Host "✅ Service nrdot-collector is running"
+          } else {
+            Write-Error "❌ Service is not running"
+          }
+
+      - name: Run local e2e tests
+        uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a
+        with:
+          retry_seconds: 15
+          retry_attempts: 20
+          agent_enabled: false
+          spec_path: distributions/${{ inputs.distribution}}/test/spec-windows.yaml
+          account_id: ${{ secrets.nr_account_id }}
+          api_key: ${{ secrets.nr_api_key }}
+          license_key: ${{ secrets.nr_ingest_key }}
+          region: ${{ vars.NR_REGION }}
+          scenario_tag: ${{ env.SCENARIO_TAG }}
+
+      - name: Validate uninstall
+        run: |
+          # Uninstall using msiexec
+          Write-Host "Uninstalling NRDOT Collector..."
+          $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList @('/x', "$env:msi_path", '/qn', '/norestart')
+          if ($process.ExitCode -ne 0) {
+            Write-Host "❌ Uninstallation failed with exit code $($process.ExitCode)"
+            exit $process.ExitCode
+          }
+          Write-Host "✅ Uninstallation completed successfully"
+
+          # Verify service was removed
+          $service = Get-Service -Name "${{ inputs.distribution }}" -ErrorAction SilentlyContinue
+          if ($service) {
+            Write-Host "❌ Service still exists after uninstall"
+            exit 1
+          }
+          Write-Host "✅ Service removed successfully"
+
+          # Verify environment variables were removed
+          $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
+          foreach ($var in $env_vars) {
+            try {
+              Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var -ErrorAction Stop | Out-Null
+              Write-Host "❌ $var still in environment registry after uninstall"
+              exit 1
+            } catch {
+              Write-Host "✅ $var no longer in environment registry after uninstall"
+            }
+          }

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -26,9 +26,9 @@ jobs:
       msi_artifact_name: ${{ steps.find-msi.outputs.msi_artifact_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
-          fetch-depth: 0 # required for tag metadata
+          fetch-depth: 1
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -42,9 +42,8 @@ jobs:
       - name: Ensure goreleaser up to date
         run: make check
 
-      - name: Generate sources
-        if: steps.cache-sources.outputs.cache-hit != 'true'
-        run: make ci DISTRIBUTIONS=${{ inputs.distribution }}
+      - name: Build distributions
+        run: make manifests-check build DISTRIBUTIONS=${{ inputs.distribution }}
 
       - name: Setup wixl # Required to build MSI
         if: inputs.publish || steps.cache-goreleaser.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -171,14 +171,6 @@ jobs:
             exit $process.ExitCode
           }
 
-          # No registry right now
-          # # Validate environment variables in registry
-          # $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
-          # foreach ($var in $env_vars) {
-          #   Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var | Out-Null
-          #   Write-Host "✅ $var found in environment registry"
-          # }
-
           Write-Host "⏳ Waiting 30 seconds for collector to spool up"
           Start-Sleep -Seconds 30
           
@@ -225,15 +217,3 @@ jobs:
             exit 1
           }
           Write-Host "✅ Service removed successfully"
-
-          # Verify environment variables were removed
-          $env_vars = @('NEW_RELIC_LICENSE_KEY', 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_RESOURCE_ATTRIBUTES')
-          foreach ($var in $env_vars) {
-            try {
-              Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name $var -ErrorAction Stop | Out-Null
-              Write-Host "❌ $var still in environment registry after uninstall"
-              exit 1
-            } catch {
-              Write-Host "✅ $var no longer in environment registry after uninstall"
-            }
-          }

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -143,10 +143,9 @@ jobs:
       - name: Install MSI
         run: |
           # Set nrdot config environment variables.
-          # Do not need to broadcast WM_SETTINGCHANGE for local env
-          $env:NEW_RELIC_LICENSE_KEY = "${{ secrets.nr_ingest_key }}"
-          $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp.nr-data.net"
-          $env:OTEL_RESOURCE_ATTRIBUTES = "testKey=$env:SCENARIO_TAG"
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "${{ secrets.nr_ingest_key }}"
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'OTEL_EXPORTER_OTLP_ENDPOINT' -Value "https://otlp.nr-data.net"
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'OTEL_RESOURCE_ATTRIBUTES' -Value "testKey=$env:SCENARIO_TAG"
 
           # Install MSI
           $log_path = Join-Path $env:TEMP "msi-install.log"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -112,12 +112,12 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
         with:
           fetch-depth: 0 # required for tag metadata
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ needs.build.outputs.msi_artifact_name }}
           path: ./msi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,20 @@ jobs:
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
+
+  windows:
+    name: Windows Validation (${{matrix.distribution}})
+    if: ${{ !github.event.act }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        distribution: ["nrdot-collector"]
+    uses: ./.github/workflows/ci-windows.yaml
+    with:
+      distribution: ${{ matrix.distribution }}
+    secrets:
+      goreleaser_key: ${{ secrets.GORELEASER_KEY }}
+      nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
+      nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
+      nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -73,7 +73,7 @@ jobs:
         id: goreleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: "2.11.2"
           args: --clean --timeout 2h
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ distributions/**/manifest-fips.yaml
 
 test/**/charts/*.tgz
 
-# tmp directory used in act builds
+# directories used in act builds
 .tmp
+.artifacts
 
 # Claude Code local context
 CLAUDE.local.md

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -46,6 +46,7 @@ type Distribution struct {
 	SkipUploadToBlobStorage bool
 	SkipChecksums           bool
 	SkipSigning             bool
+	SkipMSI                 bool
 }
 
 var (
@@ -64,6 +65,7 @@ func Generate(distFlag string, fips bool) config.Project {
 		Builds:          Builds(dist),
 		Archives:        Archives(dist),
 		NFPMs:           Packages(dist),
+		MSI:             MSI(dist),
 		Dockers:         DockerImages(dist),
 		DockerManifests: DockerManifests(dist),
 		Signs:           Signs(dist),
@@ -103,15 +105,18 @@ func NewDistribution(baseDist string, fips bool) Distribution {
 		SkipArchives:            false,
 		SkipSigning:             false,
 		SkipChecksums:           false,
+		SkipMSI:                 false,
 	}
 
 	if isNoConfigDistro(baseDist) {
 		dist.IncludeConfig = false
+		dist.SkipMSI = true
 	}
 
 	if isImageOnlyDistro(baseDist, fips) {
 		dist.Goos = []string{"linux"}
 		dist.IgnoredBuilds = nil
+		dist.SkipMSI = true
 		dist.SkipPackages = true
 		dist.SkipArchives = true
 		dist.SkipUploadToBlobStorage = true
@@ -467,6 +472,23 @@ func SignAllArtifacts() config.Sign {
 			"--detach-sign",
 			"--armor",
 			"${artifact}",
+		},
+	}
+}
+
+func MSI(dist Distribution) []config.MSI {
+	if dist.SkipMSI {
+		return nil
+	}
+	return []config.MSI{
+		{
+			ID:   dist.FullName,
+			Name: fmt.Sprintf("%s", dist.FullName), // installer filename
+			WXS:  "./windows/installer.wxs",
+			Files: []string{
+				"config.yaml",
+			},
+			Replace: false,
 		},
 	}
 }

--- a/distributions/nrdot-collector/.goreleaser.yaml
+++ b/distributions/nrdot-collector/.goreleaser.yaml
@@ -4,6 +4,12 @@ release:
   draft: true
   use_existing_draft: true
   disable: "true"
+msi:
+  - id: nrdot-collector
+    name: nrdot-collector
+    wxs: ./windows/installer.wxs
+    extra_files:
+      - config.yaml
 builds:
   - id: nrdot-collector
     goos:

--- a/distributions/nrdot-collector/test/host-expected-metrics-common.yaml
+++ b/distributions/nrdot-collector/test/host-expected-metrics-common.yaml
@@ -9,7 +9,6 @@ entities:
       - name: system.disk.io_time
       - name: system.disk.operation_time
       - name: system.disk.operations
-      - name: system.filesystem.inodes.usage
       - name: system.filesystem.usage
       - name: system.filesystem.utilization
       - name: system.memory.usage

--- a/distributions/nrdot-collector/test/host-expected-metrics-linux.yaml
+++ b/distributions/nrdot-collector/test/host-expected-metrics-linux.yaml
@@ -1,0 +1,4 @@
+entities:
+  - entityType: EXT-SERVICE
+    metrics:
+      - name: system.filesystem.inodes.usage

--- a/distributions/nrdot-collector/test/spec-local.yaml
+++ b/distributions/nrdot-collector/test/spec-local.yaml
@@ -239,7 +239,8 @@ scenarios:
     tests:
       # Tests for existence of metrics
       metrics:
-        - source: "host-expected-metrics.yaml"
+        - source: "host-expected-metrics-common.yaml"
+        - source: "host-expected-metrics-linux.yaml"
       # Tests for existence of signal + specific attributes
       nrqls: *host_metrics_nrqls
 

--- a/distributions/nrdot-collector/test/spec-nightly-action.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly-action.yaml
@@ -242,7 +242,8 @@ scenarios:
     tests:
       # Tests for existence of metrics
       metrics:
-        - source: "host-expected-metrics.yaml"
+        - source: "host-expected-metrics-common.yaml"
+        - source: "host-expected-metrics-linux.yaml"
       # Tests for existence of signal + specific attributes
       nrqls: *host_metrics_nrqls
 

--- a/distributions/nrdot-collector/test/spec-windows.yaml
+++ b/distributions/nrdot-collector/test/spec-windows.yaml
@@ -1,0 +1,115 @@
+description: nrdot-collector E2E Test (Windows)
+
+# scoping is achieved via an implicit attribute `testKey=${SCENARIO_TAG}` expected on all tested telemetry
+
+# YAML anchors for reusing test queries across scenarios
+.host_metrics_nrqls: &host_metrics_nrqls
+  - query: FROM Metric SELECT filter(count(*), state='user') as state_user WHERE metricName = 'system.cpu.utilization'
+    expected_results:
+      - key: state_user
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='idle') as state_idle WHERE metricName = 'system.cpu.utilization'
+    expected_results:
+      - key: state_idle
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='read') as direction_read WHERE metricName = 'system.disk.io'
+    expected_results:
+      - key: direction_read
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='write') as direction_write WHERE metricName = 'system.disk.io'
+    expected_results:
+      - key: direction_write
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='read') as direction_read WHERE metricName = 'system.disk.operation_time'
+    expected_results:
+      - key: direction_read
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='write') as direction_write WHERE metricName = 'system.disk.operation_time'
+    expected_results:
+      - key: direction_write
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='read') as direction_read WHERE metricName = 'system.disk.operations'
+    expected_results:
+      - key: direction_read
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='write') as direction_write WHERE metricName = 'system.disk.operations'
+    expected_results:
+      - key: direction_write
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='free') as state_free WHERE metricName = 'system.memory.usage'
+    expected_results:
+      - key: state_free
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='used') as state_used WHERE metricName = 'system.memory.usage'
+    expected_results:
+      - key: state_used
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='free') as state_free WHERE metricName = 'system.memory.utilization'
+    expected_results:
+      - key: state_free
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='used') as state_used WHERE metricName = 'system.memory.utilization'
+    expected_results:
+      - key: state_used
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='page_out') as direction_page_out WHERE metricName = 'system.paging.operations'
+    expected_results:
+      - key: direction_page_out
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='page_in') as direction_page_in WHERE metricName = 'system.paging.operations'
+    expected_results:
+      - key: direction_page_in
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='used') as state_used WHERE metricName = 'system.filesystem.usage'
+    expected_results:
+      - key: state_used
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), state='free') as state_free WHERE metricName = 'system.filesystem.usage'
+    expected_results:
+      - key: state_free
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), type != 'squashfs') as type_not_squashfs WHERE metricName = 'system.filesystem.utilization'
+    expected_results:
+      - key: type_not_squashfs
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='receive') as direction_receive WHERE metricName = 'system.network.dropped'
+    expected_results:
+      - key: direction_receive
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='transmit') as direction_transmit WHERE metricName = 'system.network.dropped'
+    expected_results:
+      - key: direction_transmit
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='receive') as direction_receive WHERE metricName = 'system.network.errors'
+    expected_results:
+      - key: direction_receive
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='transmit') as direction_transmit WHERE metricName = 'system.network.errors'
+    expected_results:
+      - key: direction_transmit
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='receive') as direction_receive WHERE metricName = 'system.network.io'
+    expected_results:
+      - key: direction_receive
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='transmit') as direction_transmit WHERE metricName = 'system.network.io'
+    expected_results:
+      - key: direction_transmit
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='receive') as direction_receive WHERE metricName = 'system.network.packets'
+    expected_results:
+      - key: direction_receive
+        lowerBoundedValue: 1
+  - query: FROM Metric SELECT filter(count(*), direction='transmit') as direction_transmit WHERE metricName = 'system.network.packets'
+    expected_results:
+      - key: direction_transmit
+        lowerBoundedValue: 1
+
+scenarios:
+  - description: host telemetry
+    tests:
+      # Tests for existence of metrics
+      metrics:
+        - source: "host-expected-metrics-common.yaml"
+      # Tests for existence of signal + specific attributes
+      nrqls: *host_metrics_nrqls

--- a/distributions/nrdot-collector/windows/installer.wxs
+++ b/distributions/nrdot-collector/windows/installer.wxs
@@ -1,0 +1,120 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+   <Product
+      Name="NRDOT Collector ({{ .Version }})"
+      Id="*"
+      UpgradeCode="BC8657F8-5174-43F3-A319-88D97945291B"
+      Version="{{ .Version }}"
+      Manufacturer="New Relic"
+      Language="1033">
+      
+      <Package
+         InstallerVersion="200"
+         Compressed="yes"
+         Comments="Windows Installer Package"
+         InstallScope="perMachine"/>
+      <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
+      <!-- <Icon Id="ProductIcon" SourceFile="opentelemetry.ico"/> -->
+      <!-- <Property Id="ARPPRODUCTICON" Value="ProductIcon"/> -->
+      <Property Id="ARPHELPLINK" Value="https://support.newrelic.com/s/"/>
+      <Property Id="ARPURLINFOABOUT" Value="https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/"/>
+      <Property Id="ARPNOREPAIR" Value="1"/>
+      <Property Id="ARPNOMODIFY" Value="1"/>
+
+      <!-- By default, sidegrades and downgrades are not allowed. -->
+      <MajorUpgrade
+         AllowDowngrades="no"
+         AllowSameVersionUpgrades="no"
+         DowngradeErrorMessage="A later version of NRDOT is already installed. Setup will now exit."/>
+
+      <Feature Id="Feature" Level="1">
+         <ComponentRef Id="ApplicationComponent"/>
+      </Feature>
+
+      <!-- Terminate install if NR license key not provided -->
+      <Condition
+         Message="A New Relic ingest key is required for NRDOT. Please provide NEW_RELIC_LICENSE_KEY during installation.">
+         Installed OR NEW_RELIC_LICENSE_KEY
+      </Condition>
+      <Property Id="NEW_RELIC_LICENSE_KEY" Secure="yes" Hidden="yes"/>
+      <Property Id="OTEL_EXPORTER_OTLP_ENDPOINT"/>
+      <Property Id="OTEL_RESOURCE_ATTRIBUTES"/>
+      <Property Id="MsiHiddenProperties" Value="NEW_RELIC_LICENSE_KEY" />
+
+      <!-- Set to bundled collector config unless one is provided-->
+      <Property Id="COLLECTOR_SVC_ARGS"/>
+      <CustomAction
+         Id="SetCollectorSvcArgs"
+         Property="COLLECTOR_SVC_ARGS"
+         Value="--config &quot;[INSTALLDIR]config.yaml&quot;"/>
+      <InstallExecuteSequence>
+         <Custom Action="SetCollectorSvcArgs" Before="InstallFiles">NOT COLLECTOR_SVC_ARGS</Custom>
+      </InstallExecuteSequence>
+
+      <Directory Id="TARGETDIR" Name="SourceDir">
+         <Directory Id="ProgramFiles64Folder">
+            <Directory Id="INSTALLDIR" Name="{{ .Binary }}">
+               <Component Id="ApplicationComponent" Guid="93B6D7EE-859A-4E0C-8196-4E66D7F77D60">
+                  <!-- Files to include -->
+                  <File
+                     Id="{{ replace .Binary "-" "_"}}.exe"
+                     Name="{{ .Binary }}.exe"
+                     Source="{{ .Binary }}.exe"
+                     KeyPath="yes"/>
+                  <File
+                     Id="config.yaml"
+                     Name="config.yaml"
+                     Source="config.yaml"/>
+
+                  <!-- Dist runs as a service on startup -->
+                  <ServiceInstall
+                     Id="Service"
+                     Name="{{ .Binary }}"
+                     DisplayName="NRDOT Collector Host"
+                     Description="NRDOT Host Distribution of the OpenTelemetry Collector"
+                     Type="ownProcess"
+                     Vital="yes"
+                     Start="auto"
+                     Account="LocalSystem"
+                     ErrorControl="normal"
+                     Arguments="[COLLECTOR_SVC_ARGS]"
+                     Interactive="no"/>
+                  <ServiceControl
+                     Id="StartStopRemoveService"
+                     Name="{{ .Binary }}"
+                     Start="install"
+                     Stop="both"
+                     Remove="uninstall"
+                     Wait="yes"/>
+
+                  <!-- System environment variables -->
+                  <RegistryKey
+                     Root="HKLM"
+                     Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment">
+                     <RegistryValue
+                        Type="string"
+                        Name="NEW_RELIC_LICENSE_KEY"
+                        Value="[NEW_RELIC_LICENSE_KEY]"/>
+                     <RegistryValue
+                        Type="string"
+                        Name="OTEL_EXPORTER_OTLP_ENDPOINT"
+                        Value="[OTEL_EXPORTER_OTLP_ENDPOINT]"/>
+                     <RegistryValue
+                        Type="string"
+                        Name="OTEL_RESOURCE_ATTRIBUTES"
+                        Value="[OTEL_RESOURCE_ATTRIBUTES]"/>
+                  </RegistryKey>
+
+                  <RegistryKey
+                     Root="HKLM"
+                     Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\{{ .Binary }}">
+                     <RegistryValue
+                        Type="expandable"
+                        Name="EventMessageFile"
+                        Value="%SystemRoot%\System32\EventCreate.exe"/>
+                  </RegistryKey>
+               </Component>
+            </Directory>
+         </Directory>
+      </Directory>
+   </Product>
+</Wix>

--- a/distributions/nrdot-collector/windows/installer.wxs
+++ b/distributions/nrdot-collector/windows/installer.wxs
@@ -1,4 +1,5 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<!-- msitools only supports schema v3 -->
    <Product
       Name="NRDOT Collector ({{ .Version }})"
       Id="*"
@@ -29,16 +30,6 @@
       <Feature Id="Feature" Level="1">
          <ComponentRef Id="ApplicationComponent"/>
       </Feature>
-
-      <!-- Terminate install if NR license key not provided -->
-      <Condition
-         Message="A New Relic ingest key is required for NRDOT. Please provide NEW_RELIC_LICENSE_KEY during installation.">
-         Installed OR NEW_RELIC_LICENSE_KEY
-      </Condition>
-      <Property Id="NEW_RELIC_LICENSE_KEY" Secure="yes" Hidden="yes"/>
-      <Property Id="OTEL_EXPORTER_OTLP_ENDPOINT"/>
-      <Property Id="OTEL_RESOURCE_ATTRIBUTES"/>
-      <Property Id="MsiHiddenProperties" Value="NEW_RELIC_LICENSE_KEY" />
 
       <!-- Set to bundled collector config unless one is provided-->
       <Property Id="COLLECTOR_SVC_ARGS"/>
@@ -85,24 +76,6 @@
                      Stop="both"
                      Remove="uninstall"
                      Wait="yes"/>
-
-                  <!-- System environment variables -->
-                  <RegistryKey
-                     Root="HKLM"
-                     Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment">
-                     <RegistryValue
-                        Type="string"
-                        Name="NEW_RELIC_LICENSE_KEY"
-                        Value="[NEW_RELIC_LICENSE_KEY]"/>
-                     <RegistryValue
-                        Type="string"
-                        Name="OTEL_EXPORTER_OTLP_ENDPOINT"
-                        Value="[OTEL_EXPORTER_OTLP_ENDPOINT]"/>
-                     <RegistryValue
-                        Type="string"
-                        Name="OTEL_RESOURCE_ATTRIBUTES"
-                        Value="[OTEL_RESOURCE_ATTRIBUTES]"/>
-                  </RegistryKey>
 
                   <RegistryKey
                      Root="HKLM"

--- a/distributions/nrdot-collector/windows/installer.wxs
+++ b/distributions/nrdot-collector/windows/installer.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-<!-- msitools only supports schema v3 -->
+<!-- ubuntu build machine only supports msitools which in turn only supports schema v3 -->
    <Product
       Name="NRDOT Collector ({{ .Version }})"
       Id="*"

--- a/distributions/nrdot-collector/windows/installer.wxs
+++ b/distributions/nrdot-collector/windows/installer.wxs
@@ -60,8 +60,8 @@
                   <ServiceInstall
                      Id="Service"
                      Name="{{ .Binary }}"
-                     DisplayName="NRDOT Collector Host"
-                     Description="NRDOT Host Distribution of the OpenTelemetry Collector"
+                     DisplayName="NRDOT Collector"
+                     Description="New Relic Distribution of OpenTelemetry Collector"
                      Type="ownProcess"
                      Vital="yes"
                      Start="auto"


### PR DESCRIPTION
### Summary
- Updates workflows to use GoReleaser Pro (necessary even if skipping msi files, otherwise they can't parse `msi` in the yaml)
- Updates Goreleaser generator to generate MSI files
- Creates MSI installer config file `installer.wxs`, [modeled after OpenTelemetry's config](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/cmd/msi-generator/windows-installer.wxs.tmpl)
- Creates Windows-specific e2e spec to omit Linux-specific host metric queries
- Divides `host-expected-metrics.yaml` into `host-expected-metrics-common.yaml` and `host-expected-metrics-linux.yaml` to support OS-specific test metrics
- Skips MSI package generation in current build pipelines (as not to publish the MSI before it's ready)

### Validation
- Creates workflow `ci-windows` which:
  - Generates an MSI artifact via GoReleaser on an ubuntu runner
  - Passes an artifact into a Windows runner for validation
  - Runs E2E tests
  - Dumps collector logs into console for debugging
  
This workflow was made to run in-parallel with the build pipeline, which is useful for quick iteration. Ultimately, we are going to want to move these scripts to an EC2 - Both for parity with our existing package (debian etc.) validation, and to eventually support additional windows versions.
