### PR TITLE
ci: fix lychee config

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,5 +1,3 @@
-include-fragments = true
-
 accept = ["200..=299"]
 require_https = true
 include_fragments = true

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -40,22 +40,25 @@ jobs:
       - name: Filter cache to successful responses only
         if: always()
         run: |
+          if [ ! -f .lycheecache ]; then
+            echo "Cache file does not exist, skipping filtering"
+            exit 0
+          fi
+
           echo "Cache contents before filtering:"
           cat .lycheecache
 
           echo -e "\nFiltering cache to remove non-2xx status codes..."
           # Keep only lines with 2xx status codes
-          if [ -f .lycheecache ]; then
-            grep ',2[0-9][0-9],' .lycheecache > .lycheecache.tmp || true
-            mv .lycheecache.tmp .lycheecache
-          fi
+          grep ',2[0-9][0-9],' .lycheecache > .lycheecache.tmp || true
+          mv .lycheecache.tmp .lycheecache
 
           echo -e "\nCache contents after filtering:"
           cat .lycheecache
 
       - name: Save lychee cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        if: always()
+        if: always() && hashFiles('.lycheecache') != ''
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
### Summary
- Fixes [broken config](https://github.com/newrelic/nrdot-collector-releases/actions/runs/24236104302/job/70758961496#step:4:102)
- Skip steps in the workflow that expect the `.lycheecache` file. This can happen if the file wasn't in the github cache and lychee failed to run, thus not producing a cache file.