### PR TITLE
test: remove tests for http/rpc metrics

### DIFF
--- a/distributions/nrdot-collector/test/spec-local.yaml
+++ b/distributions/nrdot-collector/test/spec-local.yaml
@@ -214,31 +214,6 @@ description: nrdot-collector E2E Test
     expected_results:
      - key: batch_processor
        lowerBoundedValue: 1
-  # Http metrics
-  - query: FROM Metric SELECT filter(count(*), server.address is not null) as http_server_address WHERE metricName like 'http.client.request.duration'
-    expected_results:
-      - key: http_server_address
-        lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), server.address is not null) as http_server_address WHERE metricName like 'http.client.request.body.size'
-    expected_results:
-      - key: http_server_address
-        lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), http.response.status_code is not null) as http_code WHERE metricName like 'http.client.request.duration'
-    expected_results:
-    - key: http_code
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), http.response.status_code is not null) as http_code WHERE metricName like 'http.server.request.duration'
-    expected_results:
-    - key: http_code
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), server.port is not null) as http_port WHERE metricName = 'http.server.request.duration'
-    expected_results:
-    - key: http_port
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), rpc.response.status_code is not null) as rpc_code WHERE metricName like 'rpc.%.duration'
-    expected_results:
-      - key: rpc_code
-        lowerBoundedValue: 1
 
 scenarios:
   - description: host telemetry

--- a/distributions/nrdot-collector/test/spec-nightly-action.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly-action.yaml
@@ -217,31 +217,6 @@ terraform:
     expected_results:
      - key: batch_processor
        lowerBoundedValue: 1
-  # Http metrics
-  - query: FROM Metric SELECT filter(count(*), server.address is not null) as http_server_address WHERE metricName like 'http.client.request.duration'
-    expected_results:
-      - key: http_server_address
-        lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), server.address is not null) as http_server_address WHERE metricName like 'http.client.request.body.size'
-    expected_results:
-      - key: http_server_address
-        lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), http.response.status_code is not null) as http_code WHERE metricName like 'http.client.request.duration'
-    expected_results:
-    - key: http_code
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), http.response.status_code is not null) as http_code WHERE metricName like 'http.server.request.duration'
-    expected_results:
-    - key: http_code
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), server.port is not null) as http_port WHERE metricName = 'http.server.request.duration'
-    expected_results:
-    - key: http_port
-      lowerBoundedValue: 1
-  - query: FROM Metric SELECT filter(count(*), rpc.response.status_code is not null) as rpc_code WHERE metricName like 'rpc.%.duration'
-    expected_results:
-      - key: rpc_code
-        lowerBoundedValue: 1
 
 scenarios:
   - description: host telemetry


### PR DESCRIPTION
### Summary
- Follow-up to #520 which didn't delete all references to http/rpc metrics in the tests