### PR TITLE
docs: update FIPS documentation

### DIFF
--- a/.github/workflows/check-fips-go-version.yaml
+++ b/.github/workflows/check-fips-go-version.yaml
@@ -1,0 +1,145 @@
+name: check-fips-go-version
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci-base.yaml'
+      - 'fips/README.md'
+      - '.github/workflows/check-fips-go-version.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/ci-base.yaml'
+      - 'fips/README.md'
+      - '.github/workflows/check-fips-go-version.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  check-boringssl-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract Go setup config from CI
+        id: ci-go-config
+        run: |
+          # Extract go-version and check-latest from ci-base.yaml
+          GO_VERSION_SPEC=$(yq '.jobs.lint.steps[] | select(.name == "Setup Go") | .with.go-version' .github/workflows/ci-base.yaml)
+          CHECK_LATEST=$(yq '.jobs.lint.steps[] | select(.name == "Setup Go") | .with.check-latest' .github/workflows/ci-base.yaml)
+
+          echo "version-spec=${GO_VERSION_SPEC}" >> $GITHUB_OUTPUT
+          echo "check-latest=${CHECK_LATEST}" >> $GITHUB_OUTPUT
+          echo "CI Go version spec: ${GO_VERSION_SPEC} (check-latest: ${CHECK_LATEST})"
+
+      - name: Setup Go (matching ci-base.yaml)
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.ci-go-config.outputs.version-spec }}
+          check-latest: ${{ steps.ci-go-config.outputs.check-latest }}
+
+      - name: Get actual Go version
+        id: go-version
+        run: |
+          # Get the full version string (e.g., "go1.26.0")
+          GO_FULL_VERSION=$(go version | awk '{print $3}')
+          # Strip the "go" prefix (e.g., "1.26.0")
+          GO_VERSION=${GO_FULL_VERSION#go}
+
+          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          echo "Actual Go version installed: ${GO_VERSION}"
+
+      - name: Restore BoringSSL commit cache
+        id: cache-boringssl
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: .boringssl-cache
+          key: boringssl-commit-go${{ steps.go-version.outputs.version }}
+
+      - name: Fetch BoringSSL commit from Go runtime
+        id: go-boringssl
+        run: |
+          GO_VERSION="${{ steps.go-version.outputs.version }}"
+
+          # Check if we have a cached commit SHA
+          if [ -f .boringssl-cache ]; then
+            BORINGSSL_SHA=$(cat .boringssl-cache)
+            echo "Using cached BoringSSL commit: ${BORINGSSL_SHA}"
+          else
+            # Fetch the Dockerfile from golang/go for this version
+            # The Dockerfile contains the BoringSSL commit SHA in ENV BoringV=<SHA>
+            DOCKERFILE_URL="https://raw.githubusercontent.com/golang/go/go${GO_VERSION}/src/crypto/internal/boring/Dockerfile"
+
+            echo "Fetching Dockerfile from: ${DOCKERFILE_URL}"
+            DOCKERFILE_CONTENT=$(curl -sfL "${DOCKERFILE_URL}")
+
+            if [ $? -ne 0 ]; then
+              echo "ERROR: Failed to fetch Dockerfile from Go ${GO_VERSION}"
+              echo "URL: ${DOCKERFILE_URL}"
+              exit 1
+            fi
+
+            # Extract the BoringSSL commit SHA from ENV BoringV=<SHA>
+            BORINGSSL_SHA=$(echo "${DOCKERFILE_CONTENT}" | grep -oP 'ENV BoringV=\K[a-f0-9]{40}')
+
+            if [ -z "${BORINGSSL_SHA}" ]; then
+              echo "ERROR: Could not extract BoringSSL commit SHA from Dockerfile"
+              echo "Expected line format: ENV BoringV=<40-char-hex-sha>"
+              exit 1
+            fi
+
+            # Cache the commit SHA
+            echo "${BORINGSSL_SHA}" > .boringssl-cache
+            echo "Fetched and cached BoringSSL commit: ${BORINGSSL_SHA}"
+          fi
+
+          echo "sha=${BORINGSSL_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Save BoringSSL commit cache
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        if: steps.cache-boringssl.outputs.cache-hit != 'true'
+        with:
+          path: .boringssl-cache
+          key: boringssl-commit-go${{ steps.go-version.outputs.version }}
+
+      - name: Extract documented BoringSSL commit from README
+        id: readme-boringssl
+        run: |
+          # Extract the BoringSSL commit SHA documented in fips/README.md
+          # Looking for: BoringSSL commit [`<SHA>`](...)
+          README_SHA=$(grep -oP 'BoringSSL commit \[`\K[a-f0-9]{40}' fips/README.md | head -1)
+
+          if [ -z "${README_SHA}" ]; then
+            echo "ERROR: Could not find BoringSSL commit SHA in fips/README.md"
+            exit 1
+          fi
+
+          echo "sha=${README_SHA}" >> $GITHUB_OUTPUT
+          echo "BoringSSL commit documented in README: ${README_SHA}"
+
+      - name: Compare BoringSSL commits
+        run: |
+          GO_SHA="${{ steps.go-boringssl.outputs.sha }}"
+          README_SHA="${{ steps.readme-boringssl.outputs.sha }}"
+
+          if [ "${GO_SHA}" != "${README_SHA}" ]; then
+            echo "❌ ERROR: BoringSSL commit SHA mismatch!"
+            echo ""
+            echo "  Go ${{ steps.go-version.outputs.version }} embeds: ${GO_SHA}"
+            echo "  README documents:                     ${README_SHA}"
+            echo ""
+            echo "The Go version has been updated with a different BoringSSL commit."
+            echo "This invalidates the FIPS chain of proof documented in fips/README.md"
+            echo ""
+            exit 1
+          fi
+
+          echo "✅ BoringSSL commit SHA matches between Go runtime and documentation"
+          echo "   Go version: ${{ steps.go-version.outputs.version }}"
+          echo "   BoringSSL commit: ${GO_SHA}"

--- a/fips/README.md
+++ b/fips/README.md
@@ -35,7 +35,7 @@ If you run the following command, you can verify that BoringCrypto functions are
 
 ```
 docker build --progress=plain -t fips-analyzer - << 'EOF'
-FROM golang:1.24-bullseye
+FROM golang:1.26
 COPY --from=newrelic/nrdot-collector:latest-fips /nrdot-collector /nrdot-collector
 RUN go tool nm /nrdot-collector | grep goboringcrypto
 EOF
@@ -50,7 +50,7 @@ The resulting output should be similar to the following:
 50532a0 T _cgo_39a3e70c2c46_Cfunc__goboringcrypto_AES_encrypt
 ```
 
-## TLS Handshake
+### Setup for Cipher Verification
 First, make sure you install a security scanner. We use nmap. 
 
 Please refer to install instructions [here](https://nmap.org/book/install.html)
@@ -64,7 +64,26 @@ openssl req -new -x509 -key server.key -out server.crt -days 365 -sha256 \
     -addext "subjectAltName=DNS:localhost,DNS:host.docker.internal,IP:127.0.0.1" 2>/dev/null
 ```
 
+Run the openssl server which will accept the otlpexporter's requests. The output is redirected to a log file to capture the TLS handshake details for client cipher verification.
+
+```
+openssl s_server \
+     -accept 0.0.0.0:8443 \
+     -cert server.crt \
+     -key server.key \
+     -trace \
+     -state \
+     -www \
+     > openssl-server.log 2>&1 &
+```
+
+Save the server PID so you can stop it later:
+```
+echo $! > openssl-server.pid
+```
+
 After that, create a `config.yaml` file and populate it with the following configurations.
+Note: If testing this on MacOS, you will need to replace `localhost` with `host.docker.internal`
 
 ``` 
 receivers:
@@ -82,6 +101,7 @@ receivers:
 
 exporters:
   otlphttp:
+    # replace with https://host.docker.internal:8443 when testing on MacOS
     endpoint: https://localhost:8443
     tls:
       insecure_skip_verify: true
@@ -93,92 +113,70 @@ service:
       exporters: [otlphttp]
 ```
 
-Run the server.
+Then run NRDOT via docker.
 
 ``` 
-openssl s_server \
-     -accept 0.0.0.0:8443 \
-     -cert server.crt \
-     -key server.key \
-     -trace \
-     -state \
-     -www
-```
-
-Then nmap.
-
-``` 
-nmap -sV --script ssl-enum-ciphers -p 8443 localhost
-```
-
-And finally, run docker.
-
-``` 
-docker run -d --name "nrdot-fips" --network host \
+docker run -d --name "nrdot-fips" -p 4318:4318 \
         -v "./:/certs:ro" -v "./config.yaml:/config.yaml:ro" \
-        "$DOCKER_IMAGE" --config=/config.yaml >/dev/null
+        newrelic/nrdot-collector:latest-fips --config=/config.yaml >/dev/null
 ```
 
-You should get an output similar to the following: 
+### Server Cipher Verification
+
+Configure nmap to scan NRDOT's server (port 4318) to verify which ciphers it accepts:
 
 ```
-Starting Nmap 7.98 ( https://nmap.org ) at 2025-10-02 16:04 -0400
+nmap -sV --script ssl-enum-ciphers -p 4318 localhost
+```
+
+You should get an output similar to the following (showing only FIPS-compliant ciphers):
+
+```
+Starting Nmap 7.99 ( https://nmap.org ) at 2026-04-15 17:52 -0700
 Nmap scan report for localhost (127.0.0.1)
-Host is up (0.00011s latency).
+Host is up (0.00015s latency).
 Other addresses for localhost (not scanned): ::1
 
-PORT     STATE SERVICE       VERSION
-8443/tcp open  ssl/https-alt
-|_http-trane-info: Problem with XML parsing of /evox/about
-| fingerprint-strings:
-|   FourOhFourRequest, GetRequest:
-|     HTTP/1.0 200 ok
-|     Content-type: text/html
-|     <HTML><BODY BGCOLOR="#ffffff">
-|     <pre>
-|     s_server -accept 0.0.0.0:8443 -cert server.crt -key server.key -trace -state -www
-|     This TLS version forbids renegotiation.
-|     Ciphers supported in s_server binary
-|     TLSv1.3 :TLS_AES_256_GCM_SHA384 TLSv1.3 :TLS_CHACHA20_POLY1305_SHA256
-|     TLSv1.3 :TLS_AES_128_GCM_SHA256 TLSv1.2 :ECDHE-ECDSA-AES256-GCM-SHA384
-|     TLSv1.2 :ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2 :DHE-RSA-AES256-GCM-SHA384
-|     TLSv1.2 :ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 :ECDHE-RSA-CHACHA20-POLY1305
-|     TLSv1.2 :DHE-RSA-CHACHA20-POLY1305 TLSv1.2 :ECDHE-ECDSA-AES128-GCM-SHA256
-|     TLSv1.2 :ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 :DHE-RSA-AES128-GCM-SHA256
-|     TLSv1.2 :ECDHE-ECDSA-AES256-SHA384 TLSv1.2 :ECDHE-RSA-AES256-SHA384
-|     TLSv1.2 :DHE-RSA-AES256-SHA256 TLSv1.2 :ECDHE-ECDSA-AES128-SHA256
-|_    TLSv1.2 :ECDHE-RSA
+PORT     STATE SERVICE  VERSION
+4318/tcp open  ssl/http Golang net/http server (Go-IPFS json-rpc or InfluxDB API)
 | ssl-enum-ciphers:
 |   TLSv1.2:
 |     ciphers:
-|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA (dh 2048) - A
-|       TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 (dh 2048) - A
-|       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
-|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA (dh 2048) - A
-|       TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 (dh 2048) - A
-|       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
-|       TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (dh 2048) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
-|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
-|       TLS_RSA_WITH_AES_128_CBC_SHA256 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_CBC_SHA256 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
 |     compressors:
 |       NULL
-|     cipher preference: client
+|     cipher preference: server
 |   TLSv1.3:
 |     ciphers:
-|       TLS_AKE_WITH_AES_128_GCM_SHA256 (X25519MLKEM768) - A
-|       TLS_AKE_WITH_AES_256_GCM_SHA384 (X25519MLKEM768) - A
-|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (X25519MLKEM768) - A
-|     cipher preference: client
+|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
+|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
+|     cipher preference: server
 |_  least strength: A
+```
+
+### Client Cipher Verification
+
+To verify which ciphers NRDOT offers when acting as a client (making outbound connections), wait a few seconds for NRDOT to connect to the OpenSSL server, then check the captured log:
+
+```
+# Wait for NRDOT to attempt connections
+sleep 5
+
+# Check if ClientHello was captured
+grep -q "ClientHello" openssl-server.log && echo "✓ Client connection captured" || echo "✗ No client connection found"
+
+# View the cipher suites offered by NRDOT client
+grep -A 50 "ClientHello" openssl-server.log | grep -E "TLS_|cipher" | head -20
+```
+
+The output should show only FIPS-compliant cipher suites (AES-GCM based, no CHACHA20).
+
+### Cleanup
+
+Stop and remove the containers and OpenSSL server:
+
+```
+docker stop nrdot-fips && docker rm nrdot-fips
+kill $(cat openssl-server.pid)
 ```

--- a/fips/README.md
+++ b/fips/README.md
@@ -21,7 +21,7 @@ Note: Once [golang itself is successfully FIPS 140-3 certified](https://go.dev/d
 
 ## Which distributions are FIPS compliant?
 
-Compliant artifacts have a `-fips` suffix added to the version string, e.g. `1.5.0-fips`.
+Compliant artifacts have a `-fips` suffix added to the version string, e.g. `1.12.0-fips`.
 
 _Note: FIPS-compliant distributions are only available for linux_
 

--- a/fips/README.md
+++ b/fips/README.md
@@ -131,6 +131,8 @@ You should get an output similar to the following (showing only FIPS-compliant c
 
 For the authoritative list of FIPS-compliant cipher suites, refer to the [`is_cipher_fips_compliant`](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L30) function in the automated validation script.
 
+_Note: nmap displays TLS 1.3 cipher names as `TLS_AKE_WITH_...` even though the official cipher names would drop the `AKE_WITH`, see [this issue](https://github.com/nmap/nmap/issues/2883).
+
 ```
 Starting Nmap 7.99 ( https://nmap.org ) at 2026-04-15 17:52 -0700
 Nmap scan report for localhost (127.0.0.1)
@@ -155,6 +157,7 @@ PORT     STATE SERVICE  VERSION
 |_  least strength: A
 ```
 
+
 ### Client Cipher Verification
 
 To verify which ciphers NRDOT offers when acting as a client (making outbound connections), wait a few seconds for NRDOT to connect to the OpenSSL server, then check the captured log:
@@ -170,7 +173,17 @@ grep -q "ClientHello" openssl-server.log && echo "✓ Client connection captured
 grep -A 50 "ClientHello" openssl-server.log | grep -E "TLS_|cipher" | head -20
 ```
 
-The output should show only FIPS-compliant cipher suites.
+You should get an output similar to the following (showing only FIPS-compliant cipher suites):
+
+```
+      cipher_suites (len=12)
+        {0xC0, 0x2B} TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        {0xC0, 0x2F} TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        {0xC0, 0x2C} TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        {0xC0, 0x30} TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        {0x13, 0x01} TLS_AES_128_GCM_SHA256
+        {0x13, 0x02} TLS_AES_256_GCM_SHA384
+```
 
 For the authoritative list of FIPS-compliant cipher suites, refer to the [`is_cipher_fips_compliant`](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L30) function in the automated validation script.
 

--- a/fips/README.md
+++ b/fips/README.md
@@ -1,7 +1,5 @@
 # NRDOT FIPS Compliance
 
-Note: This feature is preview-only as the FIPS-compliance is still under internal compliance review.
-
 ## What is FIPS?
 
 FIPS (Federal Information Processing Standards) are a set of computer security standards developed by NIST (National Institute of Standards and Technology) and used by non-military government agencies and contractors.
@@ -19,7 +17,7 @@ The following demonstrates the complete chain from NRDOT to the official NIST FI
 3. **BoringSSL Module**: The Go 1.26 runtime embeds BoringSSL commit [`0c6f40132b828e92ba365c6b7680e32820c63fa7`](https://github.com/golang/go/blob/go1.26.0/src/crypto/internal/boring/Dockerfile#L67), which corresponds to the [fips-20220613](https://boringssl.googlesource.com/boringssl/+/refs/tags/fips-20220613) tag
 4. **NIST Certificate**: This BoringSSL version is FIPS 140-3 validated under [NIST Certificate #4735](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735), which is valid until 2029
 
-Note: Once [golang is successfully FIPS 140-3 certified](https://go.dev/doc/security/fips140#in-process-module-versions), we will transition to using golang's native implementation.
+Note: Once [golang itself is successfully FIPS 140-3 certified](https://go.dev/doc/security/fips140#in-process-module-versions), we will transition to using golang's native implementation.
 
 ## Which distributions are FIPS compliant?
 
@@ -129,7 +127,9 @@ Configure nmap to scan NRDOT's server (port 4318) to verify which ciphers it acc
 nmap -sV --script ssl-enum-ciphers -p 4318 localhost
 ```
 
-You should get an output similar to the following (showing only FIPS-compliant ciphers):
+You should get an output similar to the following (showing only FIPS-compliant ciphers).
+
+For the authoritative list of FIPS-compliant cipher suites, refer to the [`is_cipher_fips_compliant`](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L30) function in the automated validation script.
 
 ```
 Starting Nmap 7.99 ( https://nmap.org ) at 2026-04-15 17:52 -0700
@@ -170,7 +170,9 @@ grep -q "ClientHello" openssl-server.log && echo "✓ Client connection captured
 grep -A 50 "ClientHello" openssl-server.log | grep -E "TLS_|cipher" | head -20
 ```
 
-The output should show only FIPS-compliant cipher suites (AES-GCM based, no CHACHA20).
+The output should show only FIPS-compliant cipher suites.
+
+For the authoritative list of FIPS-compliant cipher suites, refer to the [`is_cipher_fips_compliant`](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L30) function in the automated validation script.
 
 ### Cleanup
 

--- a/fips/README.md
+++ b/fips/README.md
@@ -4,13 +4,20 @@ Note: This feature is preview-only as the FIPS-compliance is still under interna
 
 ## What is FIPS?
 
-FIPS (Federal Information Processing Standards) are a set of computer security standards developed by [NIST (National Institute of Standards and Technology)](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4953) and used by non-military government agencies and contractors.
+FIPS (Federal Information Processing Standards) are a set of computer security standards developed by NIST (National Institute of Standards and Technology) and used by non-military government agencies and contractors.
 
-We are currently targeting [FIPS version 140-2](https://csrc.nist.gov/pubs/fips/140-2/upd2/final).
+We are currently targeting [FIPS version 140-3](https://csrc.nist.gov/pubs/fips/140-3/final).
 
 ## How does NRDOT achieve FIPS compliance?
 
-NRDOT achieves FIPS 140-2 compliance by instructing the golang compiler to replace the standard cryptographic library with the [FIPS 140-2-compliant library BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407) and ensuring that TLS uses [approved ciphers](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L27), see also below.
+NRDOT achieves FIPS 140-3 compliance by instructing the golang compiler to replace the standard cryptographic library with BoringSSL and ensuring that TLS uses [approved ciphers](https://github.com/newrelic/nrdot-collector-releases/blob/main/fips/validation/validate.sh#L27).
+
+The following demonstrates the complete chain from NRDOT to the official NIST FIPS certificate:
+
+1. **NRDOT Collector**: The FIPS-compliant distributions (`-fips` suffix) are built from this repository
+2. **Go Compiler**: Built using [Go 1.26](https://github.com/newrelic/nrdot-collector-releases/blob/main/.github/workflows/ci-base.yaml#L71) with [`GOEXPERIMENT=boringcrypto`](https://github.com/newrelic/nrdot-collector-releases/blob/main/distributions/nrdot-collector/.goreleaser-fips.yaml#L26) flag enabled
+3. **BoringSSL Module**: The Go 1.26 runtime embeds BoringSSL commit [`0c6f40132b828e92ba365c6b7680e32820c63fa7`](https://github.com/golang/go/blob/go1.26.0/src/crypto/internal/boring/Dockerfile#L67), which corresponds to the [fips-20220613](https://boringssl.googlesource.com/boringssl/+/refs/tags/fips-20220613) tag
+4. **NIST Certificate**: This BoringSSL version is FIPS 140-3 validated under [NIST Certificate #4735](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735), which is valid until 2029
 
 Note: Once [golang is successfully FIPS 140-3 certified](https://go.dev/doc/security/fips140#in-process-module-versions), we will transition to using golang's native implementation.
 

--- a/fips/validation/validate.sh
+++ b/fips/validation/validate.sh
@@ -29,18 +29,18 @@ print_status() {
 
 is_cipher_fips_compliant() {
     local cipher="$1"
-    
+
+    # Based on CMVP Certificate #4735 Security Policy Table 4 (Approved) and Table 6 (Non-Approved)
+
     # TLS 1.3 FIPS-approved ciphers (only specific ones, not all)
-    # NIST SP 800-52 Rev. 2 and FIPS 140-2 IG specify these TLS 1.3 ciphers:
-    if [[ "$cipher" =~ ^TLS_AES_(128|256)_GCM_SHA(256|384)$ ]] || 
+    if [[ "$cipher" =~ ^TLS_AES_(128|256)_GCM_SHA(256|384)$ ]] ||
        [[ "$cipher" =~ ^TLS_AES_(128|256)_CCM(_8)?_SHA256$ ]]; then
-        return 0  # FIPS compliant TLS 1.3
+        return 0 
     fi
-    
+
     # TLS 1.2 FIPS-approved patterns
-    [[ "$cipher" =~ ECDHE_(ECDSA|RSA).*AES_(128|256)_GCM_SHA(256|384) ]] ||
-    [[ "$cipher" =~ DHE_RSA.*AES_(128|256)_GCM_SHA(256|384) ]] ||
-    [[ "$cipher" =~ TLS_RSA_WITH_AES_(128|256)_GCM_SHA(256|384) ]] ||
+    [[ "$cipher" =~ ECDHE_(ECDSA|RSA).*AES_(128|256)_GCM_SHA(256|384|512) ]] ||
+    [[ "$cipher" =~ TLS_RSA_WITH_AES_(128|256)_GCM_SHA(256|384|512) ]] ||
     [[ "$cipher" =~ ^(AES_(128|256)_GCM|RSA.*AES_(128|256)_GCM) ]]
 }
 


### PR DESCRIPTION
### Summary
Update FIPS docs for GA:
- Reference correct CMVP Certificate and adjust for FIPS 140-3
- Fix manual verification instructions to also work locally on MacOS
- Adjust nmap output to show output for correct port + explain non-standard cipher names
- Add instructions for client verification
- Add workflow to ensure go version used to compile NRDOT uses FIPS-certified version of BoringSSL