### PR TITLE
ci: validate go version used to compile fips binary

### DIFF
--- a/.github/workflows/check-fips-compliance-reqs.yaml
+++ b/.github/workflows/check-fips-compliance-reqs.yaml
@@ -1,18 +1,18 @@
-name: check-fips-go-version
+name: check-fips-compliance-reqs
 
 on:
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/ci-base.yaml'
+      - 'fips/spec.yaml'
       - 'fips/README.md'
-      - '.github/workflows/check-fips-go-version.yaml'
+      - '.github/workflows/check-fips-compliance-reqs.yaml'
   pull_request:
     paths:
-      - '.github/workflows/ci-base.yaml'
+      - 'fips/spec.yaml'
       - 'fips/README.md'
-      - '.github/workflows/check-fips-go-version.yaml'
+      - '.github/workflows/check-fips-compliance-reqs.yaml'
   workflow_dispatch:
 
 concurrency:
@@ -27,22 +27,21 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Extract Go setup config from CI
-        id: ci-go-config
+      - name: Read FIPS spec
+        id: fips-spec
         run: |
-          # Extract go-version and check-latest from ci-base.yaml
-          GO_VERSION_SPEC=$(yq '.jobs.lint.steps[] | select(.name == "Setup Go") | .with.go-version' .github/workflows/ci-base.yaml)
-          CHECK_LATEST=$(yq '.jobs.lint.steps[] | select(.name == "Setup Go") | .with.check-latest' .github/workflows/ci-base.yaml)
+          GO_VERSION=$(yq '.go_version' fips/spec.yaml)
+          BORINGSSL_COMMIT=$(yq '.boringssl_commit' fips/spec.yaml)
 
-          echo "version-spec=${GO_VERSION_SPEC}" >> $GITHUB_OUTPUT
-          echo "check-latest=${CHECK_LATEST}" >> $GITHUB_OUTPUT
-          echo "CI Go version spec: ${GO_VERSION_SPEC} (check-latest: ${CHECK_LATEST})"
+          echo "go_version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          echo "boringssl_commit=${BORINGSSL_COMMIT}" >> $GITHUB_OUTPUT
+          echo "FIPS spec: Go ~${GO_VERSION}, BoringSSL ${BORINGSSL_COMMIT}"
 
-      - name: Setup Go (matching ci-base.yaml)
+      - name: Setup Go (matching fips/spec.yaml)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ steps.ci-go-config.outputs.version-spec }}
-          check-latest: ${{ steps.ci-go-config.outputs.check-latest }}
+          go-version: "~${{ steps.fips-spec.outputs.go_version }}"
+          check-latest: true
 
       - name: Get actual Go version
         id: go-version
@@ -108,38 +107,45 @@ jobs:
           path: .boringssl-cache
           key: boringssl-commit-go${{ steps.go-version.outputs.version }}
 
-      - name: Extract documented BoringSSL commit from README
-        id: readme-boringssl
+      - name: Validate spec is still valid for current Go runtime
+        run: |
+          GO_SHA="${{ steps.go-boringssl.outputs.sha }}"
+          SPEC_SHA="${{ steps.fips-spec.outputs.boringssl_commit }}"
+
+          if [ "${GO_SHA}" != "${SPEC_SHA}" ]; then
+            echo "❌ ERROR: BoringSSL commit SHA mismatch between Go runtime and fips/spec.yaml!"
+            echo ""
+            echo "  Go ${{ steps.go-version.outputs.version }} embeds: ${GO_SHA}"
+            echo "  fips/spec.yaml documents:            ${SPEC_SHA}"
+            echo ""
+            echo "Update fips/spec.yaml and fips/README.md to reflect the new BoringSSL commit."
+            exit 1
+          fi
+
+          echo "✅ Go runtime BoringSSL commit matches fips/spec.yaml"
+          echo "   Go version: ${{ steps.go-version.outputs.version }}"
+          echo "   BoringSSL commit: ${GO_SHA}"
+
+      - name: Validate README BoringSSL matches spec
         run: |
           # Extract the BoringSSL commit SHA documented in fips/README.md
           # Looking for: BoringSSL commit [`<SHA>`](...)
           README_SHA=$(grep -oP 'BoringSSL commit \[`\K[a-f0-9]{40}' fips/README.md | head -1)
+          SPEC_SHA="${{ steps.fips-spec.outputs.boringssl_commit }}"
 
           if [ -z "${README_SHA}" ]; then
             echo "ERROR: Could not find BoringSSL commit SHA in fips/README.md"
             exit 1
           fi
 
-          echo "sha=${README_SHA}" >> $GITHUB_OUTPUT
-          echo "BoringSSL commit documented in README: ${README_SHA}"
-
-      - name: Compare BoringSSL commits
-        run: |
-          GO_SHA="${{ steps.go-boringssl.outputs.sha }}"
-          README_SHA="${{ steps.readme-boringssl.outputs.sha }}"
-
-          if [ "${GO_SHA}" != "${README_SHA}" ]; then
-            echo "❌ ERROR: BoringSSL commit SHA mismatch!"
+          if [ "${README_SHA}" != "${SPEC_SHA}" ]; then
+            echo "❌ ERROR: BoringSSL commit SHA mismatch between fips/README.md and fips/spec.yaml!"
             echo ""
-            echo "  Go ${{ steps.go-version.outputs.version }} embeds: ${GO_SHA}"
-            echo "  README documents:                     ${README_SHA}"
+            echo "  fips/README.md documents: ${README_SHA}"
+            echo "  fips/spec.yaml documents: ${SPEC_SHA}"
             echo ""
-            echo "The Go version has been updated with a different BoringSSL commit."
-            echo "This invalidates the FIPS chain of proof documented in fips/README.md"
-            echo ""
+            echo "Update fips/README.md to match fips/spec.yaml."
             exit 1
           fi
 
-          echo "✅ BoringSSL commit SHA matches between Go runtime and documentation"
-          echo "   Go version: ${{ steps.go-version.outputs.version }}"
-          echo "   BoringSSL commit: ${GO_SHA}"
+          echo "✅ README BoringSSL commit matches fips/spec.yaml: ${README_SHA}"

--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -309,6 +309,15 @@ jobs:
           fi
           go tool nm ${BINARY} | grep '_Cfunc__goboringcrypto_' || (echo 'fips distro should not use standard crypto' && exit 1)
 
+          EXPECTED_GO_MAJOR_MINOR=$(yq '.go_version' fips/spec.yaml)
+          BINARY_GO_VERSION=$(go version -m "${BINARY}" | head -1 | grep -oP 'go\K[\d.]+')
+          BINARY_GO_MAJOR_MINOR=$(echo "${BINARY_GO_VERSION}" | cut -d. -f1,2)
+          if [[ "${BINARY_GO_MAJOR_MINOR}" != "${EXPECTED_GO_MAJOR_MINOR}" ]]; then
+            echo "❌ Binary compiled with Go ${BINARY_GO_MAJOR_MINOR}, expected Go ${EXPECTED_GO_MAJOR_MINOR} (from fips/spec.yaml)"
+            exit 1
+          fi
+          echo "✅ Binary Go version matches fips/spec.yaml: go${BINARY_GO_VERSION}"
+
       - name: Validate FIPS ciphers
         if: inputs.fips
         run: |

--- a/fips/spec.yaml
+++ b/fips/spec.yaml
@@ -1,0 +1,7 @@
+# Source of truth for FIPS build requirements, used by ci-base.yaml and check-fips-compliance-reqs.yaml
+
+# The major and minor go version used by setup-go action for builds
+go_version: "1.26"
+# BoringSSL commit embedded in the Go runtime above which has a FIPS certificate associated with it, see ./README.md
+# Source: https://github.com/golang/go/blob/go1.26.0/src/crypto/internal/boring/Dockerfile#L67
+boringssl_commit: "0c6f40132b828e92ba365c6b7680e32820c63fa7"


### PR DESCRIPTION
### Summary
- Addresses [this comment](https://github.com/newrelic/nrdot-collector-releases/pull/565#discussion_r3120168911) to add golang version validation for the actual binary as suggested in [the reply](https://github.com/newrelic/nrdot-collector-releases/pull/565#discussion_r3120893281)
- `fips/spec.yaml` acts as the source of truth for the major/minor golang version and the embedded boringssl commit that we have validated that it has a FIPS certificate (see fips/README.md)
- `ci-base.yaml` validates that the binary is actually compiled using the major/minor used in the spec
- `.github/workflows/check-fips-compliance-reqs.yaml` ensures that newer patch versions of `fips/spec.yaml::go_version` still use the same commit sha for boring SSL, so that we don't have to pin the patch version as well for CI

### Note
- I thought about deriving the go version used for all setup-go steps using a script that scrapes fips/spec.yaml but discarded it again as it would pollute lots of workflows and the current setup does ensure that we keep the golang version of ci-base in line with the FIPS requirements which is the only real formal requirement we have.