### PR TITLE
docs: fix lychee fragment errors

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,6 +1,5 @@
 accept = ["200..=299"]
 require_https = true
-include_fragments = true
 
 exclude  = [
     # disabled

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you have any questions, or to execute our corporate CLA (which is required if
 
 As noted in our [security policy](https://github.com/newrelic/nrdot-collector-releases/security/policy), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
 
-If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through our [coordinated disclosure program](https://github.com/newrelic/nrdot-collector-releases/security/policy#coordinated-disclosure-program).
+If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through our [coordinated disclosure program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/#coordinated_disclosure_program).
 
 If you would like to contribute to this project, review [these guidelines](./CONTRIBUTING.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,9 @@
 
 ## Reporting Vulnerabilities
 
-As noted in our [security policy](https://github.com/newrelic/nrdot-collector-releases/security/policy),
 New Relic is committed to the privacy and security of our customers and their data. If you believe
 you have found a security vulnerability in this project, please report it through our
-[coordinated disclosure program](https://github.com/newrelic/nrdot-collector-releases/security/policy#coordinated-disclosure-program).
+[coordinated disclosure program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/#coordinated_disclosure_program).
 
 ## GPG Signing Key
 


### PR DESCRIPTION
### Summary
- Addresses errors in [lychee run](https://github.com/newrelic/nrdot-collector-releases/actions/runs/24882520063), see [successful run](https://github.com/newrelic/nrdot-collector-releases/actions/runs/24914786471/job/72964477447) on this branch
- Fix disclosure link
- Disable fragment verification because a lot of our links link to specific lines in blobs and those apparently are not static html anchors but js-enabled anchors