### PR TITLE
feat: add k8sobjectsreceiver to experimental

### DIFF
--- a/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
@@ -220,6 +220,14 @@ Distributed under the following license(s):
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-experimental/manifest.yaml
+++ b/distributions/nrdot-collector-experimental/manifest.yaml
@@ -12,6 +12,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.150.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.150.0


### PR DESCRIPTION
### Summary
- Add k8sobjectsreceiver as requested by k8s team. Adding it to experimental for now to enable their testing, `nrdot-collector` will follow once they are ready to publish the new feature.