### PR TITLE
chore: add goreleaser pro license validation and bump goreleaser version

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -78,6 +78,15 @@ jobs:
       - name: Ensure goreleaser up to date
         run: make check
 
+      - name: Validate GoReleaser license
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
+        env:
+          GORELEASER_KEY: ${{ secrets.goreleaser_key }}
+        with:
+          distribution: goreleaser-pro
+          version: "2.15.4"
+          args: license-verify
+
       - name: Generate sources cache key
         id: sources-cache-key
         if: ${{ env.caching_enabled }}
@@ -229,7 +238,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.goreleaser_key }}
         with:
           distribution: goreleaser-pro
-          version: "2.11.2"
+          version: "2.15.4"
           args: ${{ env.goreleaser_args }}
           workdir: distributions/${{ inputs.distribution }}
 

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Build binaries & packages with GoReleaser
         if: steps.cache-goreleaser.outputs.cache-hit != 'true'
         id: goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         env:
           GORELEASER_KEY: ${{ secrets.goreleaser_key }}
           GOOS: windows

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload MSI Artifact
         id: upload-msi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ steps.find-msi.outputs.msi_artifact_name }}
           path: ${{ steps.find-msi.outputs.msi_path }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -79,7 +79,7 @@ jobs:
           GOARCH: amd64
         with:
           distribution: goreleaser-pro
-          version: "2.11.2"
+          version: "2.15.4"
           args: "--single-target --snapshot --clean --skip=publish,validate,sign,archive --timeout 2h --config .goreleaser.yaml"
           workdir: distributions/${{ inputs.distribution }}
 

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser-pro
-          version: "2.11.2"
+          version: "2.15.4"
           args: --clean --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary
* Adds license key validation for GoReleaser-Pro
* Bumps the GoReleaser version from `v2.11.2` -> `v2.15.4` (latest). This is necessary because the offline license can only be read by `v2.14` and up.
* Pins a few windows workflow commit hashes that I missed in the first PR