### PR TITLE
chore: publish msi to s3

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -178,15 +178,15 @@ jobs:
         run: |
           # Determine base skip flags and snapshot mode based on publish input
           if [ "${{ inputs.publish }}" = "true" ]; then
-            BASE_SKIP="--skip=announce,validate,msi"
+            BASE_SKIP="--skip=announce,validate"
             SNAPSHOT_FLAG=""  # No --snapshot for publishing builds to get proper versions
           else
-            BASE_SKIP="--skip=publish,validate,msi"
+            BASE_SKIP="--skip=publish,validate"
             SNAPSHOT_FLAG="--snapshot"  # Use --snapshot for dev builds to get SNAPSHOT versions
           fi
 
           if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
-            BASE_SKIP="--skip=publish,validate,sign,msi"
+            BASE_SKIP="--skip=publish,validate,sign"
           fi
 
           GORELEASER_CONFIG="${{ format('.goreleaser{0}.yaml', inputs.fips && '-fips' || '') }}"
@@ -225,6 +225,12 @@ jobs:
             echo "Tagging locally with $version to force goreleaser to use correct version in artifact names"
             git tag "$version"
           fi
+
+      - name: Setup wixl # Required to build MSI
+        if: inputs.publish || steps.cache-goreleaser.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wixl
 
       - name: Build binaries & packages with GoReleaser
         if: inputs.publish || steps.cache-goreleaser.outputs.cache-hit != 'true'
@@ -438,3 +444,4 @@ jobs:
           path: |
             docker_manifest_sha
             dist
+            !dist/**/msi

--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -444,4 +444,3 @@ jobs:
           path: |
             docker_manifest_sha
             dist
-            !dist/**/msi

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -185,7 +185,7 @@ jobs:
           # Read artifacts.json and upload each file with a path
           jq -r '.[] | select(has("path")) | .path' artifacts/dist/artifacts.json | while IFS= read -r artifact_path; do
             # Skip unrelated build artifacts
-            if [[ ! "$artifact_path" =~ \.(gz|asc|sum|deb|rpm|zip)$ ]]; then
+            if [[ ! "$artifact_path" =~ \.(gz|asc|sum|deb|rpm|zip)$ ]] || [[ "$artifact_path" =~ \.msi\.asc$ ]]; then
               echo "⏭️  Skipping: $artifact_path"
               continue
             fi

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -184,8 +184,14 @@ jobs:
 
           # Read artifacts.json and upload each file with a path
           jq -r '.[] | select(has("path")) | .path' artifacts/dist/artifacts.json | while IFS= read -r artifact_path; do
+            # Skip msi files until they're ready to release
+            if [[ "$artifact_path" =~ \.msi(\.asc)?$ ]]; then
+              echo "⏭️  Skipping MSI: $artifact_path"
+              continue
+            fi
+
             # Skip unrelated build artifacts
-            if [[ ! "$artifact_path" =~ \.(gz|asc|sum|deb|rpm|zip)$ ]] || [[ "$artifact_path" =~ \.msi\.asc$ ]]; then
+            if [[ ! "$artifact_path" =~ \.(gz|asc|sum|deb|rpm|zip)$ ]]; then
               echo "⏭️  Skipping: $artifact_path"
               continue
             fi

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -5,7 +5,8 @@ ci:
 ci_custom_matrix:
 	@# repeat --matrix arg for multiple distros
 	act push -W .github/workflows/ci.yaml \
-		--matrix distribution:nrdot-collector
+		--matrix distribution:nrdot-collector \
+		--matrix fips:false
 
 ci_custom_fips_matrix:
 	@# repeat --matrix arg for multiple distros


### PR DESCRIPTION
### Summary
This PR enables publishing of .msi artifacts to s3:

- `--skip=msi` flag removed from build (needed for goreleaser to [publish to s3](https://github.com/newrelic/nrdot-collector-releases/blob/5d95a089a204d4604c5deafbe331524bc16b753a/distributions/nrdot-collector/.goreleaser.yaml#L86-L90))
- Skips msi upload on release draft
  - See [build tree](https://github.com/newrelic/nrdot-collector-releases/actions/runs/25520475011/job/74902889547?pr=577#step:40:65) to see what files are created
  - .msi, .wsx, and .exe(unzipped) were already excluded from release, .msi.asc would have been included (but is excluded now)