### PR TITLE
chore: search through all artifacts while verifying artifacts in nightly

### DIFF
--- a/.github/actions/verify-artifacts/action.yaml
+++ b/.github/actions/verify-artifacts/action.yaml
@@ -44,7 +44,7 @@ runs:
         echo "Verifying $BUILD_TYPE artifacts exist for ${{ inputs.distribution }} with SHA: ${{ inputs.commit-sha }}"
         echo "Looking for artifact: $ARTIFACT_NAME"
 
-        if gh api "/repos/${{ github.repository }}/actions/artifacts" \
+        if gh api --paginate "/repos/${{ github.repository }}/actions/artifacts" \
            --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\")" \
            | grep -q .; then
           echo "found=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary
Nightly only searches through the first 30 artifacts when verifying artifacts. This has become a problem with the addition of the Windows CI workflow, which creates additional artifacts and has thus pushed the nightly artifact outside of the first 30. This results in [nightly failures on the main branch](https://github.com/newrelic/nrdot-collector-releases/actions/runs/25765694189/job/75677567235#step:3:41).

This PR fixes this by searching the entire list of artifacts instead of only the first 30.

### Validation
[Nightly Passes](https://github.com/newrelic/nrdot-collector-releases/actions/runs/25767602427)