### PR TITLE
docs: add msi and exe install instructions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,23 +62,3 @@ jobs:
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
-    
-  temp-windows-archive-smoke-test:
-    name: (Temporary) Windows Archive Smoke Test
-    runs-on: windows-latest
-    steps:
-      - name: Download and run collector
-        shell: pwsh
-        run: |
-          # The only point of this test is to validate that the provided .exe instructions work. This will be removed.
-          $env:collector_distro = "nrdot-collector"
-          $env:collector_version = "1.15.1"
-          $env:license_key = "${{ secrets.OTELCOMM_NR_INGEST_KEY }}"
-          Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/${env:collector_distro}_${env:collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
-          Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
-          $env:NEW_RELIC_LICENSE_KEY = $env:license_key
-          .\nrdot-collector.exe --config .\config.yaml > collector.log 2>&1 &
-          Start-Sleep -Seconds 5
-          Get-Process -Name "nrdot-collector" -ErrorAction Stop
-          Stop-Process -Name "nrdot-collector" -Force
-          Get-Content collector.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,23 @@ jobs:
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
+    
+  temp-windows-archive-smoke-test:
+    name: (Temporary) Windows Archive Smoke Test
+    runs-on: windows-latest
+    steps:
+      - name: Download and run collector
+        shell: pwsh
+        run: |
+          # The only point of this test is to validate that the provided .exe instructions work. This will be removed.
+          $env:collector_distro = "nrdot-collector"
+          $env:collector_version = "1.15.1"
+          $env:license_key = "${{ secrets.OTELCOMM_NR_INGEST_KEY }}"
+          Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/${env:collector_distro}_${env:collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
+          Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
+          $env:NEW_RELIC_LICENSE_KEY = $env:license_key
+          .\nrdot-collector.exe --config .\config.yaml > collector.log 2>&1 &
+          Start-Sleep -Seconds 5
+          Get-Process -Name "nrdot-collector" -ErrorAction Stop
+          Stop-Process -Name "nrdot-collector" -Force
+          Get-Content collector.log

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -137,7 +137,7 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_d
 Restart-Service -Name "$env:collector_distro"
 ```
 
-#### Archives
+#### Archives (.exe)
 Archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
 
 ```powershell

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -131,7 +131,8 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_d
                 -Name 'Environment' `
                 -PropertyType MultiString `
                 -Value @(
-                  "NEW_RELIC_LICENSE_KEY=$env:license_key",
+                  "NEW_RELIC_LICENSE_KEY=$env:license_key" # Required
+                  # Add any other config environment variables to this registry key (comma-separated)
                 ) `
                 -Force
 Restart-Service -Name "$env:collector_distro"

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -131,7 +131,7 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_d
                 -Name 'Environment' `
                 -PropertyType MultiString `
                 -Value @(
-                  "NEW_RELIC_LICENSE_KEY=$env:license_key" # Required
+                  "NEW_RELIC_LICENSE_KEY=$env:license_key"
                   # Add any other config environment variables to this registry key (comma-separated)
                 ) `
                 -Force

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -116,7 +116,7 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ```
 
 ### Windows MSI and Archives
-All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases), including checksums and signatures. Windows binaries and MSI files are only provided for `amd64` architecture.
+All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
 
 #### MSI Installation
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -115,8 +115,11 @@ tar -xzf collector.tar.gz
 NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml 
 ```
 
-### Windows MSI
-NRDOT must be installed from an Administrator account, and will run as a service under the `Local System` service account.
+### Windows MSI and Archives
+All windows install options are also available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases), including checksums and signatures. Windows binaries and MSI files are only provided for `amd64` architecture.
+
+#### MSI Installation
+NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.
 
 ```powershell
 $env:collector_distro = "nrdot-collector"
@@ -132,6 +135,19 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_d
                 ) `
                 -Force
 Restart-Service -Name "$env:collector_distro"
+```
+
+#### Archives
+Archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
+
+```powershell
+$env:collector_distro = "nrdot-collector"
+$env:collector_version = "1.15.1"
+$env:license_key = "YOUR_LICENSE_KEY"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/${env:collector_distro}_${env:collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
+Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
+$env:NEW_RELIC_LICENSE_KEY = $env:license_key
+.\nrdot-collector.exe --config .\config.yaml
 ```
 
 ## Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -122,32 +122,32 @@ All windows install options are available under [Releases](https://github.com/ne
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.
 
 ```powershell
-$env:collector_distro = "nrdot-collector"
-$env:collector_version="1.15.1"
-$env:license_key="YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/$env:collector_distro.msi" -OutFile "nrdot-collector.msi"
+$collector_distro = "nrdot-collector"
+$collector_version = "1.15.1"
+$license_key = "YOUR_LICENSE_KEY"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/$collector_distro.msi" -OutFile "nrdot-collector.msi"
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_distro" `
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro" `
                 -Name 'Environment' `
                 -PropertyType MultiString `
                 -Value @(
-                  "NEW_RELIC_LICENSE_KEY=$env:license_key"
+                  "NEW_RELIC_LICENSE_KEY=$license_key"
                   # Add any other config environment variables to this registry key (comma-separated)
                 ) `
                 -Force
-Restart-Service -Name "$env:collector_distro"
+Restart-Service -Name "$collector_distro"
 ```
 
 #### Archives (.exe)
 Zipped archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
 
 ```powershell
-$env:collector_distro = "nrdot-collector"
-$env:collector_version = "1.15.1"
-$env:license_key = "YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/${env:collector_distro}_${env:collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
+$collector_distro = "nrdot-collector"
+$collector_version = "1.15.1"
+$license_key = "YOUR_LICENSE_KEY"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
 Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
-$env:NEW_RELIC_LICENSE_KEY = $env:license_key
+$env:NEW_RELIC_LICENSE_KEY = $license_key
 .\nrdot-collector.exe --config .\config.yaml
 ```
 

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -116,7 +116,7 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ```
 
 ### Windows MSI and Archives
-All windows install options are also available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases), including checksums and signatures. Windows binaries and MSI files are only provided for `amd64` architecture.
+All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases), including checksums and signatures. Windows binaries and MSI files are only provided for `amd64` architecture.
 
 #### MSI Installation
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -90,7 +90,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-### RPM Installation
+##### RPM Installation
 ```bash
 export collector_distro="nrdot-collector"
 export collector_version="1.15.1"
@@ -103,7 +103,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-### Archives
+##### Archives
 Archives contain the binary and the default configuration.
 ```bash
 export collector_distro="nrdot-collector"
@@ -113,6 +113,22 @@ export license_key="YOUR_LICENSE_KEY"
 curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_${collector_version}_linux_${collector_arch}.tar.gz" --location --output collector.tar.gz
 tar -xzf collector.tar.gz
 NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml 
+```
+
+### Windows MSI
+NRDOT must be installed from an Administrator account, and will run as a service with the `Local System` service account.
+
+The OpenTelemetry Community uses a [tiered platform support model](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model). Windows falls under [tier 2](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tier-2--secondary-support), which indicates upstream issues with Windows are lower-poriority and may be fixed more slowly.
+
+> **Warning:** The instructions below store the license key as a system-wide environment variable, which is readable by all users on a machine.
+
+```powershell
+$env:collector_distro = "nrdot-collector"
+$env:collector_version="1.15.1"
+$env:license_key="YOUR_LICENSE_KEY"
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "$env:license_key"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/$env:collector_distro.msi" -OutFile "nrdot-collector.msi"
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
 ```
 
 ## Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -103,7 +103,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-##### Archives
+#### Archives
 Archives contain the binary and the default configuration.
 ```bash
 export collector_distro="nrdot-collector"

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -116,19 +116,22 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ```
 
 ### Windows MSI
-NRDOT must be installed from an Administrator account, and will run as a service with the `Local System` service account.
-
-The OpenTelemetry Community uses a [tiered platform support model](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model). Windows falls under [tier 2](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tier-2--secondary-support), which indicates upstream issues with Windows are lower-poriority and may be fixed more slowly.
-
-> **Warning:** The instructions below store the license key as a system-wide environment variable, which is readable by all users on a machine.
+NRDOT must be installed from an Administrator account, and will run as a service under the `Local System` service account.
 
 ```powershell
 $env:collector_distro = "nrdot-collector"
 $env:collector_version="1.15.1"
 $env:license_key="YOUR_LICENSE_KEY"
-Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "$env:license_key"
 Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$env:collector_version/$env:collector_distro.msi" -OutFile "nrdot-collector.msi"
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$env:collector_distro" `
+                -Name 'Environment' `
+                -PropertyType MultiString `
+                -Value @(
+                  "NEW_RELIC_LICENSE_KEY=$env:license_key",
+                ) `
+                -Force
+Restart-Service -Name "$env:collector_distro"
 ```
 
 ## Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -139,7 +139,7 @@ Restart-Service -Name "$env:collector_distro"
 ```
 
 #### Archives (.exe)
-Archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
+Zipped archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
 
 ```powershell
 $env:collector_distro = "nrdot-collector"

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -56,7 +56,7 @@ To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS`
 # Uninstall if necessary
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/x nrdot-collector.msi /qn'
 # Install with custom config
-$collector_svc_args = '--config "C:\Program Files\nrdot-collector\custom-config.yaml" --config "yaml:service::telemetry::logs::level: WARN"'
+$collector_svc_args = '--config "C:\Program Files\nrdot-collector\config.yaml" --config "yaml:service::telemetry::logs::level: WARN"'
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi COLLECTOR_SVC_ARGS=`"$collector_svc_args`" /qn"
 ```
 

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -50,6 +50,16 @@ OTELCOL_OPTIONS="--config=/etc/nrdot-collector/config.yaml --config 'yaml:servic
 systemctl reload-or-restart nrdot-collector.service
 ```
 
+#### Windows MSI
+To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS` argument during install:
+```powershell
+# Uninstall if necessary
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/x nrdot-collector.msi /qn'
+# Install with custom config
+$collector_svc_args = '--config "C:\Program Files\nrdot-collector\custom-config.yaml" --config "yaml:service::telemetry::logs::level: WARN"'
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi COLLECTOR_SVC_ARGS=`"$collector_svc_args`" /qn"
+```
+
 
 ### Collector logs
 Each component in the collector emits logs, enabled by the [internal telemetry configuration](https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs) of the collector which are often the quickest way to determine the root cause of an issue.

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -59,8 +59,6 @@ resource "aws_instance" "windows" {
                 Write-Host "MSI package fetched successfully"
 
                 # Set nrdot config environment variables.
-                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "${var.nr_ingest_key}"
-                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'OTEL_RESOURCE_ATTRIBUTES' -Value "testKey=${var.test_key}"
                 $log_path = Join-Path $env:TEMP "msi-install.log"
                 $msi_args = @(
                     '/i',
@@ -85,6 +83,19 @@ resource "aws_instance" "windows" {
                   exit $process.ExitCode
                 }
                 Write-Host "MSI installation successful"
+
+                # Set environment variables
+                New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}' `
+                -Name 'Environment' `
+                -PropertyType MultiString `
+                -Value @(
+                  "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
+                  "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+                ) `
+                -Force
+
+                # Restart service to pick up registry key change
+                Restart-Service -Name "${var.collector_distro}"
 
                 Write-Host "Waiting 30 seconds for collector to spool up..."
                 Start-Sleep -Seconds 30


### PR DESCRIPTION
### Summary

- Updates Nightly to use a more secure service-specific registry key (See: [This discussion](https://github.com/open-telemetry/opentelemetry-collector/discussions/9373) on the `opentelemetry-collector` repo)
- Adds install instructions for MSI and exe files
- Adds tip for configuring the collector on MSI install

### Validation

- [Manual run](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26535149566) of nightly passes
- Created (and deleted) temporary workflow to quickly check .exe instructions, [passed](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26533830028/job/78157261328)