### PR TITLE
chore: move ec2 userdata scripts to template files

### DIFF
--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -201,15 +201,6 @@ jobs:
             *)       NR_BACKEND_URL="https://otlp.nr-data.net" ;;
           esac
           echo "NR_BACKEND_URL=${NR_BACKEND_URL}" >> $GITHUB_ENV
-
-      - name: Terraform Setup & Workspace
-        uses: ./.github/actions/terraform-setup
-        with:
-          terraform_version: 1.9.8
-          aws_account_id: ${{ secrets.aws_account_id }}
-          working_directory: ./test/terraform/nightly
-          workspace: ${{ needs.setup.outputs.workspace }}-ubuntu
-          assume_role: "false"
       
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1

--- a/test/terraform/modules/ec2/ubuntu/main.tf
+++ b/test/terraform/modules/ec2/ubuntu/main.tf
@@ -45,28 +45,12 @@ resource "aws_instance" "ubuntu" {
   }
 
   user_data_replace_on_change = true
-  user_data                   = <<-EOF
-              #!/bin/bash
-              ################################################
-              echo 'Installing Collector'
-              export DEBIAN_FRONTEND=noninteractive
-              apt update
-              apt install unzip
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip -q awscliv2.zip
-              ./aws/install
-              deb_package_basepath='s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_distro}/${var.nrdot_version}/${var.commit_sha_short}/'
-              latest_deb_package_filename=$(aws s3 ls $${deb_package_basepath} | sort -r | grep '${var.collector_distro}' | grep 'amd64.deb$' | head -n1 | awk '{print $NF}')
-              echo "Installing collector from: $${deb_package_basepath}$${latest_deb_package_filename}"
-              aws s3 cp "$${deb_package_basepath}$${latest_deb_package_filename}" /tmp/collector.deb
-              export NRDOT_MODE=ROOT
-              dpkg -i /tmp/collector.deb
-              ################################################
-              echo 'Configuring Collector'
-              echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/${var.collector_distro}/${var.collector_distro}.conf
-              echo "OTEL_RESOURCE_ATTRIBUTES='testKey=${var.test_key}'" >> /etc/${var.collector_distro}/${var.collector_distro}.conf
-              systemctl reload-or-restart ${var.collector_distro}.service
-              sleep 30
-              journalctl | grep ${var.collector_distro}
-              EOF
+  user_data                   = templatefile("${path.module}/userdata.sh.tftpl", {
+    releases_bucket_name = var.releases_bucket_name
+    collector_distro     = var.collector_distro
+    nrdot_version        = var.nrdot_version
+    commit_sha_short     = var.commit_sha_short
+    nr_ingest_key        = var.nr_ingest_key
+    test_key             = var.test_key
+  })
 }

--- a/test/terraform/modules/ec2/ubuntu/userdata.sh.tftpl
+++ b/test/terraform/modules/ec2/ubuntu/userdata.sh.tftpl
@@ -1,0 +1,22 @@
+#!/bin/bash
+################################################
+echo 'Installing Collector'
+export DEBIAN_FRONTEND=noninteractive
+apt update
+apt install unzip
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+./aws/install
+deb_package_basepath="s3://${releases_bucket_name}/nrdot-collector-releases/${collector_distro}/${nrdot_version}/${commit_sha_short}/"
+latest_deb_package_filename=$(aws s3 ls $${deb_package_basepath} | sort -r | grep '${collector_distro}' | grep 'amd64.deb$' | head -n1 | awk '{print $NF}')
+echo "Installing collector from: $${deb_package_basepath}$${latest_deb_package_filename}"
+aws s3 cp "$${deb_package_basepath}$${latest_deb_package_filename}" /tmp/collector.deb
+export NRDOT_MODE=ROOT
+dpkg -i /tmp/collector.deb
+################################################
+echo 'Configuring Collector'
+echo 'NEW_RELIC_LICENSE_KEY=${nr_ingest_key}' >> /etc/${collector_distro}/${collector_distro}.conf
+echo "OTEL_RESOURCE_ATTRIBUTES='testKey=${test_key}'" >> /etc/${collector_distro}/${collector_distro}.conf
+systemctl reload-or-restart ${collector_distro}.service
+sleep 30
+journalctl | grep ${collector_distro}

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -40,81 +40,12 @@ resource "aws_instance" "windows" {
   }
 
   user_data_replace_on_change = true
-  user_data                   = <<-EOF
-              <powershell>
-                Write-Host "Starting AWS CLI installation..."
-                Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/i', 'https://awscli.amazonaws.com/AWSCLIV2.msi', '/qn'
-                $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-                Write-Host "AWS CLI installation completed"
-
-                Write-Host "Fetching MSI package from S3..."
-                $msi_package_basepath = "s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_distro}/${var.nrdot_version}/${var.commit_sha_short}/"
-                $latest_msi_filename = aws s3 ls $msi_package_basepath |
-                  Sort-Object -Descending |
-                  Where-Object { $_ -match "${var.collector_distro}" -and $_ -match "\.msi$" } |
-                  Select-Object -First 1 |
-                  ForEach-Object { ($_ -split '\s+')[-1] }
-                $msi_path = Join-Path $env:TEMP "collector.msi"
-                aws s3 cp "$msi_package_basepath$latest_msi_filename" $msi_path
-                Write-Host "MSI package fetched successfully"
-
-                # Set nrdot config environment variables.
-                $log_path = Join-Path $env:TEMP "msi-install.log"
-                $msi_args = @(
-                    '/i',
-                    $msi_path,
-                    '/qn',
-                    '/l*',
-                    $log_path
-                )
-                Write-Host "Starting MSI installation..."
-                $process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
-
-                # Validate install successful
-                Write-Host '`nInstallation Log (Last 200 lines):'
-                Get-Content $log_path | Select-Object -Last 200
-                if ($process.ExitCode -ne 0) {
-                  Write-Host "MSI installation failed with exit code $($process.ExitCode)"
-                  if (Test-Path $log_path) {
-                    Write-Host '`nInstallation Log - Errors and Warnings:'
-                    Get-Content $log_path | Select-String -Pattern 'error|warning|failed|exception|fatal' -Context 2,2
-                    Write-Host ''
-                  }
-                  exit $process.ExitCode
-                }
-                Write-Host "MSI installation successful"
-
-                # Set environment variables
-                $RegistryArgs = @{
-                    Path         = 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}'
-                    Name         = 'Environment'
-                    PropertyType = 'MultiString'
-                    Value        = @(
-                        "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
-                        "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
-                        # Add any other config environment variables to this registry key (comma-separated)
-                    )
-                    Force        = $true
-                }
-                New-ItemProperty @RegistryArgs
-
-                # Restart service to pick up registry key change
-                Restart-Service -Name "${var.collector_distro}"
-
-                Write-Host "Waiting 30 seconds for collector to spool up..."
-                Start-Sleep -Seconds 30
-
-                Write-Host "`nCollector logs from Windows Event Log:"
-                Get-WinEvent -LogName Application -MaxEvents 100 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -eq "${var.collector_distro}" } | Select-Object -ExpandProperty Message
-
-                # Check if service is running
-                $service = Get-Service -Name "${var.collector_distro}"
-                if ($service -and $service.Status -eq 'Running') {
-                  Write-Host "Service ${var.collector_distro} is running"
-                } else {
-                  Write-Host "Service ${var.collector_distro} is not running"
-                  exit 1
-                }
-              </powershell>
-              EOF
+  user_data                   = templatefile("${path.module}/userdata.ps1.tftpl", {
+    releases_bucket_name = var.releases_bucket_name
+    collector_distro     = var.collector_distro
+    nrdot_version        = var.nrdot_version
+    commit_sha_short     = var.commit_sha_short
+    nr_ingest_key        = var.nr_ingest_key
+    test_key             = var.test_key
+  })
 }

--- a/test/terraform/modules/ec2/windows/userdata.ps1.tftpl
+++ b/test/terraform/modules/ec2/windows/userdata.ps1.tftpl
@@ -1,0 +1,75 @@
+<powershell>
+Write-Host "Starting AWS CLI installation..."
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/i', 'https://awscli.amazonaws.com/AWSCLIV2.msi', '/qn'
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+Write-Host "AWS CLI installation completed"
+
+Write-Host "Fetching MSI package from S3..."
+$msi_package_basepath = "s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_distro}/${var.nrdot_version}/${var.commit_sha_short}/"
+$latest_msi_filename = aws s3 ls $msi_package_basepath |
+    Sort-Object -Descending |
+    Where-Object { $_ -match "${var.collector_distro}" -and $_ -match "\.msi$" } |
+    Select-Object -First 1 |
+    ForEach-Object { ($_ -split '\s+')[-1] }
+$msi_path = Join-Path $env:TEMP "collector.msi"
+aws s3 cp "$msi_package_basepath$latest_msi_filename" $msi_path
+Write-Host "MSI package fetched successfully"
+
+# Set nrdot config environment variables.
+$log_path = Join-Path $env:TEMP "msi-install.log"
+$msi_args = @(
+    '/i',
+    $msi_path,
+    '/qn',
+    '/l*',
+    $log_path
+)
+Write-Host "Starting MSI installation..."
+$process = Start-Process -Wait -PassThru msiexec.exe -ArgumentList $msi_args
+
+# Validate install successful
+Write-Host '`nInstallation Log (Last 200 lines):'
+Get-Content $log_path | Select-Object -Last 200
+if ($process.ExitCode -ne 0) {
+    Write-Host "MSI installation failed with exit code $($process.ExitCode)"
+    if (Test-Path $log_path) {
+    Write-Host '`nInstallation Log - Errors and Warnings:'
+    Get-Content $log_path | Select-String -Pattern 'error|warning|failed|exception|fatal' -Context 2,2
+    Write-Host ''
+    }
+    exit $process.ExitCode
+}
+Write-Host "MSI installation successful"
+
+# Set environment variables
+$RegistryArgs = @{
+    Path         = 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}'
+    Name         = 'Environment'
+    PropertyType = 'MultiString'
+    Value        = @(
+        "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
+        "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+        # Add any other config environment variables to this registry key (comma-separated)
+    )
+    Force        = $true
+}
+New-ItemProperty @RegistryArgs
+
+# Restart service to pick up registry key change
+Restart-Service -Name "${var.collector_distro}"
+
+Write-Host "Waiting 30 seconds for collector to spool up..."
+Start-Sleep -Seconds 30
+
+Write-Host "`nCollector logs from Windows Event Log:"
+Get-WinEvent -LogName Application -MaxEvents 100 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -eq "${var.collector_distro}" } | Select-Object -ExpandProperty Message
+
+# Check if service is running
+$service = Get-Service -Name "${var.collector_distro}"
+if ($service -and $service.Status -eq 'Running') {
+    Write-Host "Service ${var.collector_distro} is running"
+} else {
+    Write-Host "Service ${var.collector_distro} is not running"
+    exit 1
+}
+</powershell>

--- a/test/terraform/modules/ec2/windows/userdata.ps1.tftpl
+++ b/test/terraform/modules/ec2/windows/userdata.ps1.tftpl
@@ -5,10 +5,10 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 Write-Host "AWS CLI installation completed"
 
 Write-Host "Fetching MSI package from S3..."
-$msi_package_basepath = "s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_distro}/${var.nrdot_version}/${var.commit_sha_short}/"
+$msi_package_basepath = "s3://${releases_bucket_name}/nrdot-collector-releases/${collector_distro}/${nrdot_version}/${commit_sha_short}/"
 $latest_msi_filename = aws s3 ls $msi_package_basepath |
     Sort-Object -Descending |
-    Where-Object { $_ -match "${var.collector_distro}" -and $_ -match "\.msi$" } |
+    Where-Object { $_ -match "${collector_distro}" -and $_ -match "\.msi$" } |
     Select-Object -First 1 |
     ForEach-Object { ($_ -split '\s+')[-1] }
 $msi_path = Join-Path $env:TEMP "collector.msi"
@@ -43,12 +43,12 @@ Write-Host "MSI installation successful"
 
 # Set environment variables
 $RegistryArgs = @{
-    Path         = 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}'
+    Path         = 'HKLM:\SYSTEM\CurrentControlSet\Services\${collector_distro}'
     Name         = 'Environment'
     PropertyType = 'MultiString'
     Value        = @(
-        "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
-        "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+        "NEW_RELIC_LICENSE_KEY=${nr_ingest_key}",
+        "OTEL_RESOURCE_ATTRIBUTES=testKey=${test_key}"
         # Add any other config environment variables to this registry key (comma-separated)
     )
     Force        = $true
@@ -56,20 +56,20 @@ $RegistryArgs = @{
 New-ItemProperty @RegistryArgs
 
 # Restart service to pick up registry key change
-Restart-Service -Name "${var.collector_distro}"
+Restart-Service -Name "${collector_distro}"
 
 Write-Host "Waiting 30 seconds for collector to spool up..."
 Start-Sleep -Seconds 30
 
 Write-Host "`nCollector logs from Windows Event Log:"
-Get-WinEvent -LogName Application -MaxEvents 100 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -eq "${var.collector_distro}" } | Select-Object -ExpandProperty Message
+Get-WinEvent -LogName Application -MaxEvents 100 -ErrorAction SilentlyContinue | Where-Object { $_.ProviderName -eq "${collector_distro}" } | Select-Object -ExpandProperty Message
 
 # Check if service is running
-$service = Get-Service -Name "${var.collector_distro}"
+$service = Get-Service -Name "${collector_distro}"
 if ($service -and $service.Status -eq 'Running') {
-    Write-Host "Service ${var.collector_distro} is running"
+    Write-Host "Service ${collector_distro} is running"
 } else {
-    Write-Host "Service ${var.collector_distro} is not running"
+    Write-Host "Service ${collector_distro} is not running"
     exit 1
 }
 </powershell>


### PR DESCRIPTION
### Summary
Followup PR to implement one of the non-blocking improvements suggested in the [initial MSI EC2 migration PR.](https://github.com/newrelic/nrdot-collector-releases/pull/582). Migrates EC2 userdata scripts to a template files `userdata.sh.tftpl` and `userdata.ps1.tftpl`. The `.tftpl` extension is the naming pattern [recommended by hashicorp](https://developer.hashicorp.com/terraform/language/functions/templatefile).

### Validation

- Manual run of nightly [passes](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26969452502).