### PR TITLE
chore: revert windows docs changes

### DIFF
--- a/distributions/README.md
+++ b/distributions/README.md
@@ -90,7 +90,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-##### RPM Installation
+### RPM Installation
 ```bash
 export collector_distro="nrdot-collector"
 export collector_version="1.15.1"
@@ -103,7 +103,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-#### Archives
+### Archives
 Archives contain the binary and the default configuration.
 ```bash
 export collector_distro="nrdot-collector"
@@ -113,42 +113,6 @@ export license_key="YOUR_LICENSE_KEY"
 curl "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_${collector_version}_linux_${collector_arch}.tar.gz" --location --output collector.tar.gz
 tar -xzf collector.tar.gz
 NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml 
-```
-
-### Windows MSI and Archives
-All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
-
-#### MSI Installation
-NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.
-
-```powershell
-$collector_distro = "nrdot-collector"
-$collector_version = "1.15.1"
-$license_key = "YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/$collector_distro.msi" -OutFile "nrdot-collector.msi"
-Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro" `
-                -Name 'Environment' `
-                -PropertyType MultiString `
-                -Value @(
-                  "NEW_RELIC_LICENSE_KEY=$license_key"
-                  # Add any other config environment variables to this registry key (comma-separated)
-                ) `
-                -Force
-Restart-Service -Name "$collector_distro"
-```
-
-#### Archives (.exe)
-Zipped archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
-
-```powershell
-$collector_distro = "nrdot-collector"
-$collector_version = "1.15.1"
-$license_key = "YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
-Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
-$env:NEW_RELIC_LICENSE_KEY = $license_key
-.\nrdot-collector.exe --config .\config.yaml
 ```
 
 ## Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -90,7 +90,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-### RPM Installation
+##### RPM Installation
 ```bash
 export collector_distro="nrdot-collector"
 export collector_version="1.15.1"
@@ -103,7 +103,7 @@ echo "NEW_RELIC_LICENSE_KEY=${license_key}" | sudo tee -a /etc/${collector_distr
 sudo systemctl reload-or-restart "${collector_distro}.service"
 ```
 
-### Archives
+#### Archives
 Archives contain the binary and the default configuration.
 ```bash
 export collector_distro="nrdot-collector"

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -50,16 +50,6 @@ OTELCOL_OPTIONS="--config=/etc/nrdot-collector/config.yaml --config 'yaml:servic
 systemctl reload-or-restart nrdot-collector.service
 ```
 
-#### Windows MSI
-To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS` argument during install:
-```powershell
-# Uninstall if necessary
-Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/x nrdot-collector.msi /qn'
-# Install with custom config
-$collector_svc_args = '--config "C:\Program Files\nrdot-collector\config.yaml" --config "yaml:service::telemetry::logs::level: WARN"'
-Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi COLLECTOR_SVC_ARGS=`"$collector_svc_args`" /qn"
-```
-
 
 ### Collector logs
 Each component in the collector emits logs, enabled by the [internal telemetry configuration](https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs) of the collector which are often the quickest way to determine the root cause of an issue.

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -59,8 +59,6 @@ resource "aws_instance" "windows" {
                 Write-Host "MSI package fetched successfully"
 
                 # Set nrdot config environment variables.
-                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "${var.nr_ingest_key}"
-                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'OTEL_RESOURCE_ATTRIBUTES' -Value "testKey=${var.test_key}"
                 $log_path = Join-Path $env:TEMP "msi-install.log"
                 $msi_args = @(
                     '/i',
@@ -85,6 +83,19 @@ resource "aws_instance" "windows" {
                   exit $process.ExitCode
                 }
                 Write-Host "MSI installation successful"
+
+                # Set environment variables
+                New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}' `
+                -Name 'Environment' `
+                -PropertyType MultiString `
+                -Value @(
+                  "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
+                  "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+                ) `
+                -Force
+
+                # Restart service to pick up registry key change
+                Restart-Service -Name "${var.collector_distro}"
 
                 Write-Host "Waiting 30 seconds for collector to spool up..."
                 Start-Sleep -Seconds 30

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -59,6 +59,8 @@ resource "aws_instance" "windows" {
                 Write-Host "MSI package fetched successfully"
 
                 # Set nrdot config environment variables.
+                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'NEW_RELIC_LICENSE_KEY' -Value "${var.nr_ingest_key}"
+                Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name 'OTEL_RESOURCE_ATTRIBUTES' -Value "testKey=${var.test_key}"
                 $log_path = Join-Path $env:TEMP "msi-install.log"
                 $msi_args = @(
                     '/i',
@@ -83,19 +85,6 @@ resource "aws_instance" "windows" {
                   exit $process.ExitCode
                 }
                 Write-Host "MSI installation successful"
-
-                # Set environment variables
-                New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}' `
-                -Name 'Environment' `
-                -PropertyType MultiString `
-                -Value @(
-                  "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
-                  "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
-                ) `
-                -Force
-
-                # Restart service to pick up registry key change
-                Restart-Service -Name "${var.collector_distro}"
 
                 Write-Host "Waiting 30 seconds for collector to spool up..."
                 Start-Sleep -Seconds 30


### PR DESCRIPTION
### Summary

We're not ready to publish the MSI yet, so we need to revert the docs changes until we are. This PR keeps the registry key changes.