### PR TITLE
feat: publish msi and update readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,21 +62,3 @@ jobs:
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
-
-  # TEMP: Remove this job after testing
-  test-windows-install:
-    name: Test Windows Install (TEMP)
-    runs-on: windows-latest
-    steps:
-      - name: Test PowerShell install script
-        shell: pwsh
-        run: |
-          $collector_distro = "nrdot-collector"
-          $collector_version = "1.15.1"
-          $license_key = "${{ secrets.OTELCOMM_NR_INGEST_KEY }}"
-          Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
-          Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
-          $env:NEW_RELIC_LICENSE_KEY = $license_key
-          $env:OTEL_RESOURCE_ATTRIBUTES = "test.name=nrdot-windows-test"
-          Start-Process -FilePath ".\nrdot-collector.exe" -ArgumentList "--config", ".\config.yaml"
-          Start-Sleep -Seconds 120

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,21 @@ jobs:
       nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}
       nr_account_id: ${{ vars.OTELCOMM_NR_TEST_ACCOUNT_ID }}
       nr_api_key: ${{ secrets.OTELCOMM_NR_API_KEY }}
+
+  # TEMP: Remove this job after testing
+  test-windows-install:
+    name: Test Windows Install (TEMP)
+    runs-on: windows-latest
+    steps:
+      - name: Test PowerShell install script
+        shell: pwsh
+        run: |
+          $collector_distro = "nrdot-collector"
+          $collector_version = "1.15.1"
+          $license_key = "${{ secrets.OTELCOMM_NR_INGEST_KEY }}"
+          Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
+          Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
+          $env:NEW_RELIC_LICENSE_KEY = $license_key
+          $env:OTEL_RESOURCE_ATTRIBUTES = "test.name=nrdot-windows-test"
+          Start-Process -FilePath ".\nrdot-collector.exe" -ArgumentList "--config", ".\config.yaml"
+          Start-Sleep -Seconds 120

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -184,14 +184,8 @@ jobs:
 
           # Read artifacts.json and upload each file with a path
           jq -r '.[] | select(has("path")) | .path' artifacts/dist/artifacts.json | while IFS= read -r artifact_path; do
-            # Skip msi files until they're ready to release
-            if [[ "$artifact_path" =~ \.msi(\.sum)?(\.asc)?$ ]]; then
-              echo "⏭️  Skipping MSI: $artifact_path"
-              continue
-            fi
-
             # Skip unrelated build artifacts
-            if [[ ! "$artifact_path" =~ \.(gz|asc|sum|deb|rpm|zip)$ ]]; then
+            if [[ ! "$artifact_path" =~ \.(msi|gz|asc|sum|deb|rpm|zip)$ ]]; then
               echo "⏭️  Skipping: $artifact_path"
               continue
             fi

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -115,6 +115,42 @@ tar -xzf collector.tar.gz
 NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml 
 ```
 
+### Windows MSI and Archives
+All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
+
+#### MSI Installation
+NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.
+
+```powershell
+$collector_distro = "nrdot-collector"
+$collector_version = "1.15.1"
+$license_key = "YOUR_LICENSE_KEY"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/$collector_distro.msi" -OutFile "nrdot-collector.msi"
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro" `
+                -Name 'Environment' `
+                -PropertyType MultiString `
+                -Value @(
+                  "NEW_RELIC_LICENSE_KEY=$license_key"
+                  # Add any other config environment variables to this registry key (comma-separated)
+                ) `
+                -Force
+Restart-Service -Name "$collector_distro"
+```
+
+#### Archives (.exe)
+Zipped archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
+
+```powershell
+$collector_distro = "nrdot-collector"
+$collector_version = "1.15.1"
+$license_key = "YOUR_LICENSE_KEY"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
+Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
+$env:NEW_RELIC_LICENSE_KEY = $license_key
+.\nrdot-collector.exe --config .\config.yaml
+```
+
 ## Configuration
 
 ### Customize Default Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -129,14 +129,17 @@ $collector_version = "1.15.1"
 $license_key = "YOUR_LICENSE_KEY"
 Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/$collector_distro.msi" -OutFile "nrdot-collector.msi"
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro" `
-                -Name 'Environment' `
-                -PropertyType MultiString `
-                -Value @(
-                  "NEW_RELIC_LICENSE_KEY=$license_key"
-                  # Add any other config environment variables to this registry key (comma-separated)
-                ) `
-                -Force
+$RegistryArgs = @{
+    Path         = "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro"
+    Name         = 'Environment'
+    PropertyType = 'MultiString'
+    Value        = @(
+        "NEW_RELIC_LICENSE_KEY=$license_key"
+        # Add any other config environment variables to this registry key (comma-separated)
+    )
+    Force        = $true
+}
+New-ItemProperty @RegistryArgs
 Restart-Service -Name "$collector_distro"
 ```
 

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -118,7 +118,7 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ### Windows MSI and Archives
 All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
 
-> Note: Windows binaries may be delayed compared to Linux due to OpenTelemetry's upstream [tier 2 platform support policy](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model).
+> Note: Windows binaries may be delayed due to OpenTelemetry's upstream [tier 2 platform support policy](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model).
 
 #### MSI Installation
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -118,7 +118,7 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ### Windows MSI and Archives
 All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
 
-> Note: Windows binaries may be delayed due to OpenTelemetry's upstream [tier 2 platform support policy](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model).
+> Note: Windows binaries may be delayed compared to Linux if upstream Windows builds break. This is due to OpenTelemetry's upstream [tier 2 platform support policy](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model).
 
 #### MSI Installation
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -141,7 +141,7 @@ Restart-Service -Name "$collector_distro"
 ```
 
 #### Archives (.exe)
-Zipped archives contain the .exe and default configuration. The collector will run in the foreground and will not persist across reboots.
+Zipped archives contain the .exe and default configuration. The collector will run as a background process and will not persist across reboots.
 
 ```powershell
 $collector_distro = "nrdot-collector"
@@ -150,7 +150,7 @@ $license_key = "YOUR_LICENSE_KEY"
 Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/${collector_distro}_${collector_version}_windows_amd64.zip" -OutFile "nrdot-collector.zip"
 Expand-Archive -Path "nrdot-collector.zip" -DestinationPath "."
 $env:NEW_RELIC_LICENSE_KEY = $license_key
-.\nrdot-collector.exe --config .\config.yaml
+Start-Process -FilePath ".\nrdot-collector.exe" -ArgumentList "--config", ".\config.yaml"
 ```
 
 ## Configuration

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -118,6 +118,8 @@ NEW_RELIC_LICENSE_KEY="${license_key}" ./nrdot-collector --config ./config.yaml
 ### Windows MSI and Archives
 All windows install options are available under [Releases](https://github.com/newrelic/nrdot-collector-releases/releases). Windows binaries and MSI files are only provided for `amd64` architecture.
 
+> Note: Windows binaries may be delayed compared to Linux due to OpenTelemetry's upstream [tier 2 platform support policy](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/platform-support.md#tiered-platform-support-model).
+
 #### MSI Installation
 NRDOT must be installed from an Administrator account, and will run as an automatic service under the `Local System` service account.
 

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -50,6 +50,16 @@ OTELCOL_OPTIONS="--config=/etc/nrdot-collector/config.yaml --config 'yaml:servic
 systemctl reload-or-restart nrdot-collector.service
 ```
 
+#### Windows MSI
+To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS` argument during install:
+```powershell
+# Uninstall if necessary
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/x nrdot-collector.msi /qn'
+# Install with custom config
+$collector_svc_args = '--config "C:\Program Files\nrdot-collector\config.yaml" --config "yaml:service::telemetry::logs::level: WARN"'
+Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi COLLECTOR_SVC_ARGS=`"$collector_svc_args`" /qn"
+```
+
 
 ### Collector logs
 Each component in the collector emits logs, enabled by the [internal telemetry configuration](https://opentelemetry.io/docs/collector/internal-telemetry/#configure-internal-logs) of the collector which are often the quickest way to determine the root cause of an issue.

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -51,7 +51,9 @@ systemctl reload-or-restart nrdot-collector.service
 ```
 
 #### Windows MSI
-To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS` argument during install:
+To tweak configuration in our MSI files, you may supply the `COLLECTOR_SVC_ARGS` argument during install.
+
+These instructions assume the collector has been installed - For a fresh install, see the [MSI Install instructions](./README.md#msi-installation). 
 ```powershell
 # Uninstall if necessary
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList '/x nrdot-collector.msi /qn'

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -85,15 +85,18 @@ resource "aws_instance" "windows" {
                 Write-Host "MSI installation successful"
 
                 # Set environment variables
-                New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}' `
-                -Name 'Environment' `
-                -PropertyType MultiString `
-                -Value @(
-                  "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
-                  "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
-                  # Add any other config environment variables to this registry key (comma-separated)
-                ) `
-                -Force
+                $RegistryArgs = @{
+                    Path         = 'HKLM:\SYSTEM\CurrentControlSet\Services\${var.collector_distro}'
+                    Name         = 'Environment'
+                    PropertyType = 'MultiString'
+                    Value        = @(
+                        "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
+                        "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+                        # Add any other config environment variables to this registry key (comma-separated)
+                    )
+                    Force        = $true
+                }
+                New-ItemProperty @RegistryArgs
 
                 # Restart service to pick up registry key change
                 Restart-Service -Name "${var.collector_distro}"

--- a/test/terraform/modules/ec2/windows/main.tf
+++ b/test/terraform/modules/ec2/windows/main.tf
@@ -91,6 +91,7 @@ resource "aws_instance" "windows" {
                 -Value @(
                   "NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}",
                   "OTEL_RESOURCE_ATTRIBUTES=testKey=${var.test_key}"
+                  # Add any other config environment variables to this registry key (comma-separated)
                 ) `
                 -Force
 


### PR DESCRIPTION
This should not be merged until the MSI is ready for publishing.

### Summary

- Enables MSI publishing
- Adds install and troubleshooting info to readmes
- Adds a note about possible windows delays caused by the upstream tier 2 support policy for Windows