### PR TITLE
ci: fix cache steps not being skipped on main branch

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "~1.26"
-          cache: ${{ env.caching_enabled }}
+          cache: ${{ env.caching_enabled == 'true' }}
           check-latest: true
 
       - name: Tidy go.mod files
@@ -89,7 +89,7 @@ jobs:
 
       - name: Generate sources cache key
         id: sources-cache-key
-        if: ${{ env.caching_enabled }}
+        if: env.caching_enabled == 'true'
         run: |
           SOURCES_HASH="${{ hashFiles(
             format('distributions/{0}/manifest.yaml', inputs.distribution),
@@ -102,7 +102,7 @@ jobs:
       - name: Cache sources
         id: cache-sources
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        if: ${{ env.caching_enabled }}
+        if: env.caching_enabled == 'true'
         with:
           path: |
             distributions/${{ inputs.distribution }}/_build
@@ -207,7 +207,7 @@ jobs:
 
       - name: Cache goreleaser build
         id: cache-goreleaser
-        if: ${{ env.caching_enabled }}
+        if: env.caching_enabled == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |

--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -48,7 +48,7 @@ permissions:
   id-token: write
 
 env:
-  caching_enabled: false
+  caching_enabled: ${{ !inputs.publish }}
   registry: "${{ secrets.aws_account_id }}.dkr.ecr.us-east-1.amazonaws.com"
 
 jobs:

--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -48,7 +48,7 @@ permissions:
   id-token: write
 
 env:
-  caching_enabled: ${{ !inputs.publish }}
+  caching_enabled: false
   registry: "${{ secrets.aws_account_id }}.dkr.ecr.us-east-1.amazonaws.com"
 
 jobs:


### PR DESCRIPTION
### Summary
In the most recent CI run against the main branch, I noticed the following behaviors:

- Source files were [retrieved from the cache](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26970496439/job/79584192745#step:9:1) instead of being generated
- GoReleaser binaries were [both fetched from the cache,](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26970496439/job/79584192745#step:23:1) and [generated](https://github.com/newrelic/nrdot-collector-releases/actions/runs/26970496439/job/79584192745#step:26:25)

The intended behavior is that caching is skipped when publishing is enabled (i.e. [on push to the main branch](https://github.com/newrelic/nrdot-collector-releases/blob/e0b6abc06d61303451909d358bb6fc755d41b5b4/.github/workflows/ci.yaml#L53) so that nightly can run against non-cached artifacts. This was not happening because GitHub Actions considers "false" as a truthy string in `if:` blocks.

### Validation
- [Cache steps successfully skipped](https://github.com/newrelic/nrdot-collector-releases/actions/runs/27161797655/job/80178916433#step:10:1) on test commit with caching set to false
- [Cache still works](https://github.com/newrelic/nrdot-collector-releases/actions/runs/27163062012/job/80183217960?pr=592#step:11:1) when caching enabled