### PR TITLE
chore: add version tag name to msi installer

### DIFF
--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -483,7 +483,7 @@ func MSI(dist Distribution) []config.MSI {
 	return []config.MSI{
 		{
 			ID:   dist.FullName,
-			Name: fmt.Sprintf("%s", dist.FullName), // installer filename
+			Name: fmt.Sprintf("%s_{{ .Version }}_windows_{{ .MsiArch }}", dist.FullName), // installer filename
 			WXS:  "./windows/installer.wxs",
 			Files: []string{
 				"config.yaml",

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -127,7 +127,7 @@ NRDOT must be installed from an Administrator account, and will run as an automa
 $collector_distro = "nrdot-collector"
 $collector_version = "1.16.0"
 $license_key = "YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_windows_x64.msi" -OutFile "nrdot-collector.msi"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_${collector_version}_windows_x64.msi" -OutFile "nrdot-collector.msi"
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
 $RegistryArgs = @{
     Path         = "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro"

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -127,7 +127,7 @@ NRDOT must be installed from an Administrator account, and will run as an automa
 $collector_distro = "nrdot-collector"
 $collector_version = "1.16.0"
 $license_key = "YOUR_LICENSE_KEY"
-Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/$collector_version/$collector_distro.msi" -OutFile "nrdot-collector.msi"
+Invoke-WebRequest -Uri "https://github.com/newrelic/nrdot-collector-releases/releases/download/${collector_version}/${collector_distro}_windows_x64.msi" -OutFile "nrdot-collector.msi"
 Start-Process -Wait -PassThru msiexec.exe -ArgumentList "/i nrdot-collector.msi /qn"
 $RegistryArgs = @{
     Path         = "HKLM:\SYSTEM\CurrentControlSet\Services\$collector_distro"

--- a/distributions/nrdot-collector/.goreleaser.yaml
+++ b/distributions/nrdot-collector/.goreleaser.yaml
@@ -6,7 +6,7 @@ release:
   disable: "true"
 msi:
   - id: nrdot-collector
-    name: nrdot-collector
+    name: nrdot-collector_{{ .Version }}_windows_{{ .MsiArch }}
     wxs: ./windows/installer.wxs
     extra_files:
       - config.yaml


### PR DESCRIPTION
### Summary
Artifact names are required to have a [release tag](https://github.com/newrelic/nrdot-collector-releases/actions/runs/27175588127/job/80223742204#step:6:994) prior to being published. Currently, all instances of our .msi files are only called `nrdot-collector.msi`. This PR updates them to have more descriptive names, e.g. `nrdot-collector_1.16.0_windows_amd64.msi`.