### PR TITLE
ci: move terraform setup and destroy to workflows

### DIFF
--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -314,8 +314,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Configure AWS Credentials
-        id: configure-aws-credentials-for-eks
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        id: configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: ${{ secrets.aws_oidc_role_arn }}
           aws-region: us-east-1

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -260,7 +260,7 @@ jobs:
         shell: bash
         run: |
           RANDOM_SUFFIX=$(echo $RANDOM$RANDOM | md5sum | cut -c1-7)
-          echo "SCENARIO_TAG=e2e-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
+          echo "SCENARIO_TAG=e2e-ubuntu-${{ matrix.version }}-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
 
       - name: Terraform Apply
         run: |
@@ -333,7 +333,7 @@ jobs:
         shell: bash
         run: |
           RANDOM_SUFFIX=$(echo $RANDOM$RANDOM | md5sum | cut -c1-7)
-          echo "SCENARIO_TAG=e2e-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
+          echo "SCENARIO_TAG=e2e-windows-${{ matrix.version }}-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
 
       - name: Terraform Apply
         run: |

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -270,9 +270,6 @@ jobs:
             -var="platform=ubuntu" \
             -var="platform_version=${{ matrix.version }}"
 
-      - name: Test failure handling
-        run: exit 1
-
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1
         with:
@@ -345,9 +342,6 @@ jobs:
             -var="test_key=${{ env.SCENARIO_TAG }}" \
             -var="platform=windows" \
             -var="platform_version=${{ matrix.version }}"
-
-      - name: Test failure handling
-        run: exit 1
 
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -326,7 +326,7 @@ jobs:
           terraform_version: 1.9.8
           aws_account_id: ${{ secrets.aws_account_id }}
           working_directory: ./test/terraform/nightly
-          workspace: ${{ needs.setup.outputs.workspace }}-windows
+          workspace: ${{ needs.setup.outputs.workspace }}-windows-${{ matrix.version }}
           assume_role: "false"
       
       - name: Generate E2E scenario tag

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -188,7 +188,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.aws_oidc_role_arn }}
           aws-region: us-east-1
-      
+
       - name: Configure kubectl
         run: |
           aws eks update-kubeconfig --name aws-ci-e2etest --region us-east-1
@@ -201,7 +201,7 @@ jobs:
             *)       NR_BACKEND_URL="https://otlp.nr-data.net" ;;
           esac
           echo "NR_BACKEND_URL=${NR_BACKEND_URL}" >> $GITHUB_ENV
-      
+
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1
         env:
@@ -224,6 +224,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup]
     if: needs.setup.outputs.ubuntu-e2e == 'true'
+    strategy:
+      matrix:
+        version: ["22.04", "24.04"]
     env:
       TF_INPUT: "false"
       TF_VAR_aws_account_id: ${{ secrets.aws_account_id }}
@@ -252,6 +255,20 @@ jobs:
           working_directory: ./test/terraform/nightly
           workspace: ${{ needs.setup.outputs.workspace }}-ubuntu
           assume_role: "false"
+      
+      - name: Generate E2E scenario tag
+        shell: bash
+        run: |
+          RANDOM_SUFFIX=$(echo $RANDOM$RANDOM | md5sum | cut -c1-7)
+          echo "SCENARIO_TAG=e2e-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
+
+      - name: Terraform Apply
+        run: |
+          cd ./test/terraform/nightly &&
+          terraform apply -auto-approve \
+            -var="test_key=${{ env.SCENARIO_TAG }}" \
+            -var="platform=ubuntu" \
+            -var="platform_version=${{ matrix.version }}"
 
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1
@@ -264,12 +281,25 @@ jobs:
           api_key: ${{ secrets.nr_api_key }}
           license_key: ${{ secrets.nr_ingest_key }}
           region: ${{ vars.NR_REGION }}
+          scenario_tag: ${{ env.SCENARIO_TAG }}
+
+      - name: Terraform Destroy
+        if: always()
+        run: |
+          cd ./test/terraform/nightly &&
+          terraform destroy -auto-approve \
+            -var="test_key=${{ env.SCENARIO_TAG }}" \
+            -var="platform=ubuntu" \
+            -var="platform_version=${{ matrix.version }}"
 
   e2e-tests-windows:
     name: E2E Tests (Windows EC2)
     runs-on: ubuntu-latest
     needs: [setup]
     if: needs.setup.outputs.windows-e2e == 'true'
+    strategy:
+      matrix:
+        version: ["2025"]
     env:
       TF_INPUT: "false"
       TF_VAR_aws_account_id: ${{ secrets.aws_account_id }}
@@ -299,6 +329,20 @@ jobs:
           workspace: ${{ needs.setup.outputs.workspace }}-windows
           assume_role: "false"
       
+      - name: Generate E2E scenario tag
+        shell: bash
+        run: |
+          RANDOM_SUFFIX=$(echo $RANDOM$RANDOM | md5sum | cut -c1-7)
+          echo "SCENARIO_TAG=e2e-${GITHUB_SHA:0:7}-${RANDOM_SUFFIX}" >> $GITHUB_ENV
+
+      - name: Terraform Apply
+        run: |
+          cd ./test/terraform/nightly &&
+          terraform apply -auto-approve \
+            -var="test_key=${{ env.SCENARIO_TAG }}" \
+            -var="platform=windows" \
+            -var="platform_version=${{ matrix.version }}"
+
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1
         with:
@@ -310,3 +354,13 @@ jobs:
           api_key: ${{ secrets.nr_api_key }}
           license_key: ${{ secrets.nr_ingest_key }}
           region: ${{ vars.NR_REGION }}
+          scenario_tag: ${{ env.SCENARIO_TAG }}
+
+      - name: Terraform Destroy
+        if: always()
+        run: |
+          cd ./test/terraform/nightly &&
+          terraform destroy -auto-approve \
+            -var="test_key=${{ env.SCENARIO_TAG }}" \
+            -var="platform=windows" \
+            -var="platform_version=${{ matrix.version }}"

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -270,6 +270,9 @@ jobs:
             -var="platform=ubuntu" \
             -var="platform_version=${{ matrix.version }}"
 
+      - name: Test failure handling
+        run: exit 1
+
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1
         with:
@@ -342,6 +345,9 @@ jobs:
             -var="test_key=${{ env.SCENARIO_TAG }}" \
             -var="platform=windows" \
             -var="platform_version=${{ matrix.version }}"
+
+      - name: Test failure handling
+        run: exit 1
 
       - name: Run Action-based E2E Tests
         uses: newrelic/newrelic-integration-e2e-action@d0c7c2b8f9af227365d71c6b7fddbc024c9e331a # v1

--- a/.github/workflows/deploy-and-e2e.yaml
+++ b/.github/workflows/deploy-and-e2e.yaml
@@ -253,7 +253,7 @@ jobs:
           terraform_version: 1.9.8
           aws_account_id: ${{ secrets.aws_account_id }}
           working_directory: ./test/terraform/nightly
-          workspace: ${{ needs.setup.outputs.workspace }}-ubuntu
+          workspace: ${{ needs.setup.outputs.workspace }}-ubuntu-${{ matrix.version }}
           assume_role: "false"
       
       - name: Generate E2E scenario tag

--- a/distributions/nrdot-collector/test/spec-nightly-ubuntu.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly-ubuntu.yaml
@@ -134,38 +134,6 @@ description: nrdot-collector E2E Nightly Test - Ubuntu EC2
         lowerBoundedValue: 1
 
 scenarios:
-  - description: ubuntu 22.04 jammy - ec2 host metrics and resourcedetection
-    before:
-      - |
-        cd ../../../test/terraform/nightly &&
-        terraform apply -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=ubuntu" \
-          -var="platform_version=22.04"
-    after:
-      - |
-        cd ../../../test/terraform/nightly &&
-        terraform destroy -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=ubuntu" \
-          -var="platform_version=22.04"
-    tests:
-      nrqls: *host_metrics_nrqls
-
-  - description: ubuntu 24.04 noble - ec2 host metrics and resourcedetection
-    before:
-      - |
-        cd ../../../test/terraform/nightly &&
-        terraform apply -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=ubuntu" \
-          -var="platform_version=24.04"
-    after:
-      - |
-        cd ../../../test/terraform/nightly &&
-        terraform destroy -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=ubuntu" \
-          -var="platform_version=24.04"
+  - description: ubuntu - ec2 host metrics and resourcedetection
     tests:
       nrqls: *host_metrics_nrqls

--- a/distributions/nrdot-collector/test/spec-nightly-windows.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly-windows.yaml
@@ -106,20 +106,6 @@ description: nrdot-collector E2E Test (Windows)
         lowerBoundedValue: 1
 
 scenarios:
-  - description: windows 2025 - ec2 host metrics
-    before:
-      - | 
-        cd ../../../test/terraform/nightly &&
-        terraform apply -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=windows" \
-          -var="platform_version=2025"
-    after:
-      - | 
-        cd ../../../test/terraform/nightly &&
-        terraform destroy -auto-approve \
-          -var="test_key=${SCENARIO_TAG}" \
-          -var="platform=windows" \
-          -var="platform_version=2025"
+  - description: windows - ec2 host metrics
     tests:
       nrqls: *host_metrics_nrqls


### PR DESCRIPTION
### Summary
Followup PR to address [feedback](https://github.com/newrelic/nrdot-collector-releases/pull/582#discussion_r3282919361) in the initial MSI PR. This moves the terraform apply / destroy steps out of the spec file and into the parent workflow. This has the following benefits:

* Faster nightly runs from different versions on parallel runners (previously would run all platform versions in sequence)
* Reduces copy-paste for testing additional versions in nightly (now we only need to add additional matrix inputs)

### Validation
* [Nightly passes](https://github.com/newrelic/nrdot-collector-releases/actions/runs/27243649310)
* Terraform correctly destroys on workflow failure (see: [test run](https://github.com/newrelic/nrdot-collector-releases/actions/runs/27243385984/job/80452120417#step:7:1) with added failure step)