### PR TITLE
fix: replace deprecated aliases for hostmetricsreceiver, metricstransformprocessor and resourcedetectionprocessor

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -5,7 +5,8 @@ ci:
 ci_custom_matrix:
 	@# repeat --matrix arg for multiple distros
 	act push -W .github/workflows/ci.yaml \
-		--matrix distribution:nrdot-collector
+		--matrix distribution:nrdot-collector \
+		--matrix fips:false
 
 ci_custom_fips_matrix:
 	@# repeat --matrix arg for multiple distros

--- a/distributions/TROUBLESHOOTING.md
+++ b/distributions/TROUBLESHOOTING.md
@@ -68,7 +68,7 @@ Each component in the collector emits logs, enabled by the [internal telemetry c
 By default, the log `level` is set to `INFO` which is usually sufficient for debugging, but you can use the above-mentioned instructions to override it to a value that suits your needs.
 ```
 # Example warning log by hostmetricsreceiver
-2025-01-01T23:19:05.097Z    warn    filesystemscraper/factory.go:48    No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only    {"otelcol.component.id": "hostmetrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
+2025-01-01T23:19:05.097Z    warn    filesystemscraper/factory.go:48    No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only    {"otelcol.component.id": "host_metrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
 # Example of logs of successful startup and processing
 2025-01-01T23:19:14.828Z    info    service@v0.121.0/service.go:281    Everything is ready. Begin running and processing data.
 2025-01-01T23:19:16.031Z    info    Metrics    {"otelcol.component.id": "debug", "otelcol.component.kind": "Exporter", "otelcol.signal": "metrics", "resource metrics": 4, "metrics": 9, "data points": 32}

--- a/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
+++ b/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
@@ -23,7 +23,7 @@ ports:
 
 config:
   receivers:
-    hostmetrics:
+    host_metrics:
       collection_interval: 60s
       scrapers:
         cpu:
@@ -51,7 +51,7 @@ config:
     pipelines:
       metrics/host:
         receivers:
-          - hostmetrics
+          - host_metrics
         processors:
           - resourcedetection/env
         exporters:

--- a/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
+++ b/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
@@ -53,7 +53,7 @@ config:
         receivers:
           - host_metrics
         processors:
-          -resource_detection/env
+          - resource_detection/env
         exporters:
           - otlphttp
       # disable preset pipelines

--- a/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
+++ b/distributions/nrdot-collector-experimental/test/smoke-collector-values.yaml
@@ -32,7 +32,7 @@ config:
     zipkin: null
     prometheus: null
   processors:
-    resourcedetection/env:
+   resource_detection/env:
       detectors: ["env"]
       timeout: 2s
       override: true
@@ -53,7 +53,7 @@ config:
         receivers:
           - host_metrics
         processors:
-          - resourcedetection/env
+          -resource_detection/env
         exporters:
           - otlphttp
       # disable preset pipelines

--- a/distributions/nrdot-collector/README.md
+++ b/distributions/nrdot-collector/README.md
@@ -58,8 +58,8 @@ Process metrics are disabled by default due to their high cardinality. To enable
 Example configuration:
 ```shell
 newrelic/nrdot-collector --config /etc/nrdot-collector/config.yaml \
---config='yaml:receivers::hostmetrics::scrapers::processes: ' \
---config='yaml:receivers::hostmetrics::scrapers::process: { metrics: { process.cpu.utilization: { enabled: true }, process.cpu.time: { enabled: false } } }'
+--config='yaml:receivers::host_metrics::scrapers::processes: ' \
+--config='yaml:receivers::host_metrics::scrapers::process: { metrics: { process.cpu.utilization: { enabled: true }, process.cpu.time: { enabled: false } } }'
 ```
 
 ---

--- a/distributions/nrdot-collector/TROUBLESHOOTING.md
+++ b/distributions/nrdot-collector/TROUBLESHOOTING.md
@@ -25,7 +25,7 @@ The `hostmetricsreceiver` auto-detects files to scrape system metrics from. When
 
 Warning message indicating this issue:
 ```
-2025-01-01T21:08:21.097Z	warn	filesystemscraper/factory.go:48	No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only	{"otelcol.component.id": "hostmetrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
+2025-01-01T21:08:21.097Z	warn	filesystemscraper/factory.go:48	No `root_path` config set when running in docker environment, will report container filesystem stats. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only	{"otelcol.component.id": "host_metrics", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
 ```
 
 **Resolution:** Follow the [receiver's docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md#collecting-host-metrics-from-inside-a-container-linux-only) to mount the host file system and configure `root_path`:
@@ -33,7 +33,7 @@ Warning message indicating this issue:
 docker run -v /:/hostfs \
 -e NEW_RELIC_LICENSE_KEY='license-key' newrelic/nrdot-collector \
 --config /etc/nrdot-collector/config.yaml \
---config 'yaml:receivers::hostmetrics::root_path: /hostfs'
+--config 'yaml:receivers::host_metrics::root_path: /hostfs'
 ```
 
 ## Gateway Mode

--- a/distributions/nrdot-collector/TROUBLESHOOTING.md
+++ b/distributions/nrdot-collector/TROUBLESHOOTING.md
@@ -10,9 +10,9 @@ If you are [seeing telemetry getting ingested into New Relic](../TROUBLESHOOTING
 Example log messages indicating this issue:
 ```
 # example 1
-2025-01-01T22:49:09.110Z        warn    system/system.go:143    failed to get host ID   {"otelcol.component.id": "resourcedetection", "otelcol.component.kind" : "Processor", "otelcol.pipeline.id": "logs/host", "otelcol.signal": "logs", "error": "failed to obtain \"host.id\": error detecting resource: host id not found in: /etc/machine-id or /var/lib/dbus/machine-id"}
+2025-01-01T22:49:09.110Z        warn    system/system.go:143    failed to get host ID   {"otelcol.component.id": "resource_detection", "otelcol.component.kind" : "Processor", "otelcol.pipeline.id": "logs/host", "otelcol.signal": "logs", "error": "failed to obtain \"host.id\": error detecting resource: host id not found in: /etc/machine-id or /var/lib/dbus/machine-id"}
 # example 2
-2025-01-01T23:07:27.866Z        warn    system/system.go:143    failed to get host ID   {"otelcol.component.id": "resourcedetection", "otelcol.component.kind": "Processor", "otelcol.pipeline.id": "metrics/host", "otelcol.signal": "metrics", "error": "empty \"host.id\""}
+2025-01-01T23:07:27.866Z        warn    system/system.go:143    failed to get host ID   {"otelcol.component.id": "resource_detection", "otelcol.component.kind": "Processor", "otelcol.pipeline.id": "metrics/host", "otelcol.signal": "metrics", "error": "empty \"host.id\""}
 ```
 
 **Resolution:** Set the `host.id` attribute manually via the [environment variable](./README.md#use-case-specific-configuration) `OTEL_RESOURCE_ATTRIBUTES`:

--- a/distributions/nrdot-collector/assert-invariants-agent-control.sh
+++ b/distributions/nrdot-collector/assert-invariants-agent-control.sh
@@ -28,7 +28,7 @@ for env_var in "${env_vars[@]}"; do
 done
 
 echo 'Checking for host.id detection'
-yq -e '.processors.resourcedetection.system.resource_attributes["host.id"].enabled == "true"' "${core_distro_dir}/config.yaml" ||
+yq -e '.processors.resource_detection.system.resource_attributes["host.id"].enabled == "true"' "${core_distro_dir}/config.yaml" ||
   { echo "expected host.id detection to be enabled"; exit 1; }
 
 

--- a/distributions/nrdot-collector/config.yaml
+++ b/distributions/nrdot-collector/config.yaml
@@ -7,7 +7,7 @@ receivers:
       grpc:
       http:
 
-  hostmetrics:
+  host_metrics:
     # Default collection interval is 60s. Lower if you need finer granularity.
     collection_interval: 60s
     scrapers:
@@ -66,7 +66,7 @@ receivers:
 
 processors:
   # group system.cpu metrics by cpu
-  metricstransform:
+  metrics_transform:
     transforms:
       - include: system.cpu.utilization
         action: update
@@ -169,7 +169,7 @@ processors:
 
   batch:
 
-  resourcedetection:
+  resource_detection:
     detectors: ["system"]
     system:
       hostname_sources: ["os"]
@@ -177,14 +177,14 @@ processors:
         host.id:
           enabled: true
 
-  resourcedetection/cloud:
+  resource_detection/cloud:
     detectors: ["gcp", "ec2", "azure"]
     timeout: 2s
     override: true
 
   # Gives OTEL_RESOURCE_ATTRIBUTES precedence over other sources.
   # host.id is set from env whenever the collector is orchestrated by NR Agents.
-  resourcedetection/env:
+  resource_detection/env:
     detectors: ["env"]
     timeout: 2s
     override: true
@@ -198,10 +198,10 @@ exporters:
 service:
   pipelines:
     metrics/host:
-      receivers: [hostmetrics]
+      receivers: [host_metrics]
       processors:
         - memory_limiter
-        - metricstransform
+        - metrics_transform
         - filter/exclude_cpu_utilization
         - filter/exclude_memory_utilization
         - filter/exclude_memory_usage
@@ -212,27 +212,27 @@ service:
         - filter/exclude_network
         - attributes/exclude_system_paging
         - transform/host
-        - resourcedetection
-        - resourcedetection/cloud
-        - resourcedetection/env
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
         - cumulativetodelta
         - batch
       exporters: [otlphttp]
     logs/host:
       receivers: [file_log]
-      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+      processors: [memory_limiter, transform, resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
   extensions: [health_check]

--- a/distributions/nrdot-collector/test/host-collector-values.yaml
+++ b/distributions/nrdot-collector/test/host-collector-values.yaml
@@ -31,7 +31,7 @@ command:
     - '"--config=yaml:extensions::health_check::endpoint: ${env:MY_POD_IP}:13133"'
     # enable virtual filesystems for e2e tests running in containers (kind/Docker)
     # where overlay is the only available filesystem
-    - '"--config=yaml:receivers::hostmetrics::scrapers::filesystem::include_virtual_filesystems: true"'
+    - '"--config=yaml:receivers::host_metrics::scrapers::filesystem::include_virtual_filesystems: true"'
 
 extraEnvs:
   - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/distributions/nrdot-collector/test/spec-nightly-ubuntu.yaml
+++ b/distributions/nrdot-collector/test/spec-nightly-ubuntu.yaml
@@ -134,6 +134,6 @@ description: nrdot-collector E2E Nightly Test - Ubuntu EC2
         lowerBoundedValue: 1
 
 scenarios:
-  - description: ubuntu - ec2 host metrics and resourcedetection
+  - description: ubuntu - ec2 host metrics and resource detection
     tests:
       nrqls: *host_metrics_nrqls

--- a/fips/README.md
+++ b/fips/README.md
@@ -88,7 +88,7 @@ receivers:
         tls:
           cert_file: /certs/server.crt
           key_file: /certs/server.key
-  hostmetrics:
+  host_metrics:
     collection_interval: 1s
     scrapers:
       memory:
@@ -103,7 +103,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [otlp, hostmetrics]
+      receivers: [otlp, host_metrics]
       exporters: [otlphttp]
 ```
 

--- a/fips/validation/validate.sh
+++ b/fips/validation/validate.sh
@@ -83,7 +83,7 @@ receivers:
         tls:
           cert_file: /certs/server.crt
           key_file: /certs/server.key
-  hostmetrics:
+  host_metrics:
     collection_interval: 1s
     scrapers:
       memory:
@@ -97,7 +97,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [otlp, hostmetrics]
+      receivers: [otlp, host_metrics]
       exporters: [otlphttp]
 
 EOF


### PR DESCRIPTION
### Summary
In #601 , the changelogs for the bump from v0.150.0 to v0.154.0 indicates the following component names are being deprecated:

- `processor/resourcedetection -> processor/resource_detection`
- `processor/metricstransform -> processor/metrics_transform`
- `receiver/hostmetrics -> receiver/host_metrics`

This PR updates the config to reflect these changes.