### PR TITLE
Add Oracle/SQL Server receivers and secret management providers

### DIFF
--- a/distributions/nrdot-collector/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector/THIRD_PARTY_NOTICES.md
@@ -12,7 +12,39 @@ can be found at https://github.com/newrelic/nrdot-collector-releases.
 
 
 
+## [github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver](https://github.com/newrelic-forks/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nrsqlserverreceiver](https://github.com/newrelic-forks/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/newrelic/nrdot-collector-components/processor/adaptivetelemetryprocessor](https://github.com/newrelic/nrdot-collector-components)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):
 
@@ -77,6 +109,14 @@ Distributed under the following license(s):
 
 
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):
 
@@ -236,6 +276,14 @@ Distributed under the following license(s):
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):
@@ -253,6 +301,22 @@ Distributed under the following license(s):
 
 
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):
 

--- a/distributions/nrdot-collector/manifest.yaml
+++ b/distributions/nrdot-collector/manifest.yaml
@@ -18,11 +18,16 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.154.0
+  - gomod: github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver v0.154.0
+  - gomod: github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nrsqlserverreceiver v0.154.0
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.154.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.154.0
@@ -52,6 +57,9 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.60.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.60.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.60.0
+  # Secret Management Providers
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.154.0
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
   # Why: Fixes CVE-2026-42151 and CVE-2026-42154


### PR DESCRIPTION
Receivers:
- oracledbreceiver, sqlserverreceiver (upstream contrib)
- nroracledbreceiver, nrsqlserverreceiver (newrelic-forks)

Processors:
- deltatorateprocessor (upstream contrib)

Providers:
- secretsmanagerprovider (AWS Secrets Manager)
- aesprovider (AES-encrypted config values)