### PR TITLE
feat: add sqlqueryreceiver to nrdot-collector-experimental

### DIFF
--- a/.chloggen/kbauer_add-sqlqueryreceiver-to-experimental.yaml
+++ b/.chloggen/kbauer_add-sqlqueryreceiver-to-experimental.yaml
@@ -4,7 +4,7 @@
 change_type: feature
 
 # Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
-issues: []
+issues: [632]
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add the `sqlqueryreceiver` to the `nrdot-collector-experimental` distribution.

--- a/.chloggen/kbauer_add-sqlqueryreceiver-to-experimental.yaml
+++ b/.chloggen/kbauer_add-sqlqueryreceiver-to-experimental.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
+change_type: feature
+
+# Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `sqlqueryreceiver` to the `nrdot-collector-experimental` distribution.
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.claude/skills/chloggen/skill.md
+++ b/.claude/skills/chloggen/skill.md
@@ -1,0 +1,44 @@
+---
+name: chloggen
+description: |
+  Use when adding a changelog entry to this repo — creating or editing files in
+  `.chloggen/`, running `make chlog-new/-validate/-preview/-update`, or preparing
+  a user-facing PR whose release notes should show up in CHANGELOG.md. Covers
+  the draft-PR-first dance that lets `make chlog-new` auto-fill the PR number
+  and change type.
+---
+
+# chloggen Workflow
+
+This repo uses chloggen to generate CHANGELOG.md from per-PR YAML entries in `.chloggen/`. Every user-facing PR needs one entry.
+
+## Commands
+
+- `make chlog-new` — create a template entry named after the current branch, auto-filling `issues:` and `change_type` if a PR already exists.
+- `make chlog-validate` — validate all pending entries. Fails if any entry has empty `issues:`.
+- `make chlog-preview` — dry-run the CHANGELOG update.
+- `make chlog-update` — consume entries and write to CHANGELOG.md (release only).
+
+Change types allowed here: `feature`, `bug_fix`, `docs`. The wrapper in `scripts/chloggen-wrapper.sh` translates these to chloggen's built-ins — don't hand-edit it.
+
+## Preferred workflow (draft PR first)
+
+`make chlog-new` reads the PR for the current branch to prefill `issues:` and infer `change_type` from the PR title's conventional-commit prefix (`feat` → feature, `fix` → bug_fix, `docs` → docs). To use that, create the PR as a draft first so nothing publishes before the entry lands.
+
+1. Make code changes on your branch, commit, push.
+2. `gh pr create --draft --title "feat: ..." --body "..."`
+3. `make chlog-new` — writes `.chloggen/<branch>.yaml` with `issues: [N]` and `change_type` prefilled.
+4. Edit the file: fill in `note:` (one-line description). Add `subtext:` only if extra detail is warranted.
+5. `make chlog-validate` — should pass now.
+6. Commit the entry, push.
+7. `gh pr ready <PR>` — promote out of draft.
+
+## If you already opened a non-draft PR
+
+`make chlog-new` still works; run it and it will fill in the PR number. Or hand-edit the template and set `issues: [N]` yourself. Commit as a follow-up.
+
+## Gotchas
+
+- `chlog-validate` errors with `specify one or more issues #'s` when `issues:` is empty — that means no PR existed when `make chlog-new` ran. Fill it in and re-run.
+- Entry filename is `<branch-name>.yaml` (slashes replaced with underscores). Don't rename it.
+- `.chloggen/TEMPLATE.yaml` and `.chloggen/config.yaml` are not entries; the wrapper skips them.

--- a/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
@@ -340,6 +340,14 @@ Distributed under the following license(s):
 
 
 
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [go.opentelemetry.io/collector/component](https://go.opentelemetry.io/collector/component)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-experimental/manifest.yaml
+++ b/distributions/nrdot-collector-experimental/manifest.yaml
@@ -23,6 +23,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.156.0
   - gomod: github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver v0.156.1
   - gomod: github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nrsqlserverreceiver v0.156.1
 processors:


### PR DESCRIPTION
## Summary
- Adds `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver` to the `nrdot-collector-experimental` distribution manifest
- Regenerated sources and `THIRD_PARTY_NOTICES.md` via `make licenses`
- Adds a repo-scoped `chloggen` skill under `.claude/skills/` documenting the changelog workflow and the draft-PR-first dance that lets `make chlog-new` auto-fill the PR number and change type as claude just coincidentally inferred that it should use chloggen (added in #616), so this should guide the process a bit more 