### PR TITLE
fix: remove receiver/jmxreceiver

### DIFF
--- a/.chloggen/agarvin_remove-jmxreceiver.yaml
+++ b/.chloggen/agarvin_remove-jmxreceiver.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
+change_type: feature
+# Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
+issues: [635]
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `receiver/jmxreceiver` from `nrdot-collector` and `nrdot-collector-experimental`.
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - This component was removed upstream in `v0.157.0` following its deprecation in `v0.145.0`.

--- a/.chloggen/agarvin_remove-jmxreceiver.yaml
+++ b/.chloggen/agarvin_remove-jmxreceiver.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
-change_type: feature
+change_type: bug_fix
 # Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
 issues: [635]
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).

--- a/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-experimental/THIRD_PARTY_NOTICES.md
@@ -252,14 +252,6 @@ Distributed under the following license(s):
 
 
 
-## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
-
-Distributed under the following license(s):
-
-* Apache-2.0
-
-
-
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector-experimental/manifest.yaml
+++ b/distributions/nrdot-collector-experimental/manifest.yaml
@@ -12,7 +12,6 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.156.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.156.0

--- a/distributions/nrdot-collector/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector/THIRD_PARTY_NOTICES.md
@@ -244,14 +244,6 @@ Distributed under the following license(s):
 
 
 
-## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
-
-Distributed under the following license(s):
-
-* Apache-2.0
-
-
-
 ## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 Distributed under the following license(s):

--- a/distributions/nrdot-collector/component-inventory.yaml
+++ b/distributions/nrdot-collector/component-inventory.yaml
@@ -27,7 +27,6 @@ receivers:
   filelogreceiver: [Host, k8s]
   haproxyreceiver: [OHI-haproxy]
   hostmetricsreceiver: [Host, k8s, OHI]
-  jmxreceiver: [OHI-kafka]
   k8seventsreceiver: [OHI, k8s]
   kafkametricsreceiver: [OHI-kafka]
   kafkareceiver: [OHI-kafka]

--- a/distributions/nrdot-collector/manifest.yaml
+++ b/distributions/nrdot-collector/manifest.yaml
@@ -12,7 +12,6 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.156.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.156.0

--- a/scripts/build/validate-source-files.sh
+++ b/scripts/build/validate-source-files.sh
@@ -7,30 +7,21 @@ set -e
 
 # default values
 fips=false
+distributions=""
 
 while getopts d:f: flag
 do
     case "${flag}" in
-        d) distro=${OPTARG};;
+        d) distributions=${OPTARG};;
         f) fips=${OPTARG};;
         *) exit 1;;
     esac
 done
 
-if [ -z ${distro} ]; then
+if [ -z "${distributions}" ]; then
     echo "Distribution not provided. Please provide a distribution with -d."
     exit 1
 fi
-
-path="distributions/${distro}/_build"
-if [ ${fips} = true ]; then
-    path="${path}-fips"
-fi
-if [ ! -d "$path" ]; then
-    echo "❌ $path not found!"
-    exit 1
-fi
-cd "$path"
 
 files=(
     "components.go" "go.mod" "go.sum" "main_others.go"
@@ -39,19 +30,35 @@ files=(
 if [ ${fips} = true ]; then
     files+=("fips.go")
 fi
-missing_files=()
 
-for file in "${files[@]}"; do
-    if [ ! -f "$file" ]; then
-        missing_files+=("$file")
+overall_exit=0
+
+for distro in $(echo "$distributions" | tr "," "\n"); do
+    path="distributions/${distro}/_build"
+    if [ ${fips} = true ]; then
+        path="${path}-fips"
+    fi
+    if [ ! -d "$path" ]; then
+        echo "❌ $path not found!"
+        overall_exit=1
+        continue
+    fi
+
+    missing_files=()
+    for file in "${files[@]}"; do
+        if [ ! -f "${path}/${file}" ]; then
+            missing_files+=("$file")
+        else
+            echo "Found: ${path}/${file}"
+        fi
+    done
+
+    if [ ${#missing_files[@]} -eq 0 ]; then
+        echo "✅ ${distro}: All source files found!"
     else
-        echo "Found: $file"
+        echo "❌ ${distro}: files not found: ${missing_files[*]}"
+        overall_exit=1
     fi
 done
 
-if [ ${#missing_files[@]} -eq 0 ]; then
-    echo "✅ All source files found!"
-else
-    echo "❌ files not found: ${missing_files[*]}"
-    exit 1
-fi
+exit ${overall_exit}

--- a/scripts/build/validate-source-files.sh
+++ b/scripts/build/validate-source-files.sh
@@ -33,8 +33,8 @@ fi
 
 overall_exit=0
 
-for distro in $(echo "$distributions" | tr "," "\n"); do
-    path="distributions/${distro}/_build"
+for distribution in $(echo "$distributions" | tr "," "\n"); do
+    path="distributions/${distribution}/_build"
     if [ ${fips} = true ]; then
         path="${path}-fips"
     fi
@@ -54,9 +54,9 @@ for distro in $(echo "$distributions" | tr "," "\n"); do
     done
 
     if [ ${#missing_files[@]} -eq 0 ]; then
-        echo "✅ ${distro}: All source files found!"
+        echo "✅ ${distribution}: All source files found!"
     else
-        echo "❌ ${distro}: files not found: ${missing_files[*]}"
+        echo "❌ ${distribution}: files not found: ${missing_files[*]}"
         overall_exit=1
     fi
 done


### PR DESCRIPTION
### Summary
* Removes the `receiver/jmxreceiver` component from `nrdot-collector` and `nrdot-collector-experimental. Its [deprecation](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45740) was announced in [v0.145.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.145.0) and has been removed from upstream in [v0.157.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.157.0).
* Updates `validate-source-files.sh` to take an array of components. This change fixes local execution of `make ci`,  where this script was recently added to consolidate make targets.