### PR TITLE
chore: update version bump script to automatically create a chlog entry for ohi components

### DIFF
--- a/.github/workflows/ci-bump-component-versions.yaml
+++ b/.github/workflows/ci-bump-component-versions.yaml
@@ -191,7 +191,7 @@ jobs:
           env:
             GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           run: |
-            ./scripts/release/generate-version-bump-chlog.sh -c "${{ env.current_beta_core }}" -n "${{ env.next_beta_core }}"
+            ./scripts/release/generate-version-bump-chlog.sh -c "${{ env.current_beta_core }}" -n "${{ env.next_beta_core }}" -f "${{ steps.fetch_dep_versions.outputs.nr_fork_matching }}"
 
         - name: Commit changelog entry
           if: ${{ !env.ACT && steps.bump_component_versions.outputs.has_changes == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -197,11 +197,14 @@ CHLOGGEN_CONFIG := "${SRC_ROOT}/.chloggen/config.yaml"
 BRANCH_NAME?=$(shell git branch --show-current)
 PR_NUMBER?=$(shell gh pr view $(BRANCH_NAME) --json number --jq '.number' 2>/dev/null)
 
+CHLOG_FILE?=
+
 # Generate a new changelog entry.
 # The .issues field will be pre-populated with the PR number if one exists.
+# Override CHLOG_FILE to set a custom filename: make chlog-new CHLOG_FILE=my-entry
 .PHONY: chlog-new
 chlog-new: ${CHLOGGEN}
-	./scripts/misc/chloggen-wrapper.sh -b $(CHLOGGEN) -n
+	./scripts/misc/chloggen-wrapper.sh -b $(CHLOGGEN) -n $(if $(CHLOG_FILE),-f $(CHLOG_FILE))
 
 .PHONY: chlog-validate
 chlog-validate: ${CHLOGGEN}

--- a/scripts/misc/chloggen-wrapper.sh
+++ b/scripts/misc/chloggen-wrapper.sh
@@ -12,6 +12,7 @@ CHLOGGEN_DIR="$REPO_DIR/.chloggen"
 
 CHLOGGEN=''
 COMMAND=''
+FILENAME=''
 
 set_command() {
     if [ -n "$COMMAND" ]; then
@@ -21,10 +22,11 @@ set_command() {
     COMMAND=$1
 }
 
-while getopts nvpub: flag
+while getopts nvpub:f: flag
 do
     case "${flag}" in
         b) CHLOGGEN=${OPTARG};;
+        f) FILENAME=${OPTARG};;
         n) set_command new;;
         v) set_command validate;;
         p) set_command preview;;
@@ -42,14 +44,19 @@ if [ -z "$COMMAND" ]; then
     exit 1
 fi
 
+if [ -n "$FILENAME" ] && [ "$COMMAND" != "new" ]; then
+    echo "⚠️ Warning: -f is only used with -n; ignoring filename '$FILENAME'." >&2
+fi
+
 # --new command (no need for translation)
 if [ "$COMMAND" = new ]; then
     BRANCH_NAME=$(git branch --show-current)
-    filepath=$("$CHLOGGEN" new --config "$CHLOGGEN_DIR/config.yaml" --filename "$BRANCH_NAME" | sed -n 's/^Changelog entry template copied to: //p')
+    ENTRY_FILENAME="${FILENAME:-$BRANCH_NAME}"
+    filepath=$("$CHLOGGEN" new --config "$CHLOGGEN_DIR/config.yaml" --filename "$ENTRY_FILENAME" | sed -n 's/^Changelog entry template copied to: //p')
 
     # Pre-populate the issues field with the PR number if one exists for this branch
     if gh auth status >/dev/null 2>&1; then
-        PR_NUMBER=$(gh pr view "$BRANCH_NAME" --json number --jq '.number' 2>/dev/null)
+        PR_NUMBER=$(gh pr view "$BRANCH_NAME" --json number --jq '.number' 2>/dev/null || true)
         if [ -n "$PR_NUMBER" ]; then
             yq -i ".issues = [$PR_NUMBER] | .issues style=\"flow\"" "$filepath"
         else
@@ -57,7 +64,7 @@ if [ "$COMMAND" = new ]; then
         fi
 
         # Infer change_type from the conventional commit prefix of the PR title
-        PR_TITLE=$(gh pr view "$BRANCH_NAME" --json title --jq '.title' 2>/dev/null)
+        PR_TITLE=$(gh pr view "$BRANCH_NAME" --json title --jq '.title' 2>/dev/null || true)
         case "$PR_TITLE" in
             feat*) yq -i '.change_type = "feature"' "$filepath";;
             perf*) yq -i '.change_type = "feature"' "$filepath";;

--- a/scripts/release/generate-version-bump-chlog.sh
+++ b/scripts/release/generate-version-bump-chlog.sh
@@ -7,38 +7,52 @@
 # Must be run after the PR is created so that `make chlog-new` can populate the
 # .issues field with the PR number.
 #
-# Usage: generate-version-bump-chlog.sh -c <current_beta_core> -n <next_beta_core>
+# Usage: generate-version-bump-chlog.sh -c <current_beta_core> -n <next_beta_core> -f <next_beta_fork>
 #   -c  current otel beta core version (e.g. v0.147.0)
 #   -n  next otel beta core version    (e.g. v0.148.0)
+#   -f  next otel beta fork version    (e.g. v0.148.0-nr1)
 
 set -euo pipefail
 
 CURRENT_BETA_CORE=''
 NEXT_BETA_CORE=''
+NEXT_BETA_FORK=''
 
-while getopts c:n: flag
+while getopts c:n:f: flag
 do
     case "${flag}" in
         c) CURRENT_BETA_CORE=${OPTARG};;
         n) NEXT_BETA_CORE=${OPTARG};;
+        f) NEXT_BETA_FORK=${OPTARG};;
         *) exit 1;;
     esac
 done
 
-if [[ -z "$CURRENT_BETA_CORE" || -z "$NEXT_BETA_CORE" ]]; then
-    echo "Usage: $0 -c <current_beta_core> -n <next_beta_core>" >&2
+if [[ -z "$CURRENT_BETA_CORE" || -z "$NEXT_BETA_CORE" || -z "$NEXT_BETA_FORK" ]]; then
+    echo "Usage: $0 -c <current_beta_core> -n <next_beta_core> -f <next_beta_fork>" >&2
     exit 1
 fi
 
-filepath=$(make -s chlog-new)
+core_filepath=$(make -s chlog-new CHLOG_FILE=core_version_bump)
 
 # The .issues and .change_type fields are automatically populated by the make target if a PR has been created prior
 yq -i "
   .note = \"Bump otel component versions from ${CURRENT_BETA_CORE} to ${NEXT_BETA_CORE}\" |
   ... comments=\"\"
-" "$filepath"
+" "$core_filepath"
 
 echo "New changelog entry added:"
-cat "$filepath"
+cat "$core_filepath"
+
+fork_filepath=$(make -s chlog-new CHLOG_FILE=fork_version_bump)
+
+yq -i "
+  .note = \"Bump \`nroracledbreceiver\` and \`nrsqlserverreceiver\` to ${NEXT_BETA_FORK}\" |
+  .subtext = \"- For the list of changes to these components, refer to [their changelog](https://github.com/newrelic-forks/opentelemetry-collector-contrib/blob/receiver/nrsqlserverreceiver/${NEXT_BETA_FORK}/NR_CHANGELOG.md).\" |
+  ... comments=\"\"
+" "$fork_filepath"
+
+echo "New changelog entry added:"
+cat "$fork_filepath"
 
 make chlog-validate


### PR DESCRIPTION
### Summary

- Updates the version bump script to automatically create a chlog entry for ohi components. It will create two changelog entries now: One for otel core components, and one for the nr-fork components. The changelog entries are meant to match the current pattern for our release notes.
- Updates `chloggen-wrapper.sh` with the ability to define the name of the file created

### Validation

- [Successful PR ](https://github.com/newrelic/nrdot-collector-releases/pull/642) run from this branch
- Example `make chlog-update` output:

```.md
- Bump otel component versions from v0.156.0 to v0.157.0 (#123)
- Bump `nroracledbreceiver` and `nrsqlserverreceiver` to v0.157.2 (#123)
  - For the list of changes to these components, refer to [their changelog](https://github.com/newrelic-forks/opentelemetry-collector-contrib/blob/receiver/nrsqlserverreceiver/v0.157.2/NR_CHANGELOG.md).
```