### PR TITLE
fix: replace deprecated alias for processor/cumulative_to_delta

### DIFF
--- a/.chloggen/agarvin_cumulative-to-delta.yaml
+++ b/.chloggen/agarvin_cumulative-to-delta.yaml
@@ -9,4 +9,4 @@ note: Rename configuration nodes `cumulativetodelta` to `cumulative_to_delta` fo
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: '- The original name remains available as a deprecated alias.'
+subtext: '- The original name `cumulativetodelta` remains available as a deprecated alias.'

--- a/.chloggen/agarvin_cumulative-to-delta.yaml
+++ b/.chloggen/agarvin_cumulative-to-delta.yaml
@@ -1,0 +1,12 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
+change_type: bug_fix
+# Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
+issues: [644]
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename configuration nodes `cumulativetodelta` to `cumulative_to_delta` following the component rename in `v0.157.0``
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: '- The original name remains available as a deprecated alias.'

--- a/.claude/skills/version-bump-analysis/skill.md
+++ b/.claude/skills/version-bump-analysis/skill.md
@@ -91,7 +91,7 @@ This script efficiently fetches and extracts only the relevant version section u
      - `providers:` section
    - Extract component names from gomod paths (e.g., `receiver/filelogreceiver` → `receiver/filelog`)
    - Build a set of all unique component names used across all distributions
-   - Component names in CHANGELOG use format: `receiver/filelog`, `processor/cumulativetodelta`, etc.
+   - Component names in CHANGELOG use format: `receiver/filelog`, `processor/cumulative_to_delta`, etc.
 
 2. **Extract version information from the PR**:
    - Use `gh pr view <pr_number> --json body --jq .body` to fetch the PR description

--- a/distributions/nrdot-collector/config.yaml
+++ b/distributions/nrdot-collector/config.yaml
@@ -141,7 +141,7 @@ processors:
       - key: type
         action: delete
 
-  cumulativetodelta:
+  cumulative_to_delta:
 
   transform/host:
     metric_statements:
@@ -215,7 +215,7 @@ service:
         - resource_detection
         - resource_detection/cloud
         - resource_detection/env
-        - cumulativetodelta
+        - cumulative_to_delta
         - batch
       exporters: [otlphttp]
     logs/host:


### PR DESCRIPTION
### Summary
* The cumulative to delta processer has recently been renamed to `cumulative_to_delta` with `cumulativetodelta` availalbe as a deprecated alias.