### PR TITLE
chore: update broken docs.github.com links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
 To contribute,
-[fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this repository, commit your changes,
-and [send a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+[fork](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo) this repository, commit your changes,
+and [send a Pull Request](https://docs.github.com/en/pull-requests/reference/pull-requests).
 
 Note that our [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)
 applies to all platforms and venues related to this project; please follow it in all your


### PR DESCRIPTION
## Summary
- The nightly `check-links` workflow (run [30621471045](https://github.com/newrelic/nrdot-collector-releases/actions/runs/30621471045)) flagged two 301 redirects in CONTRIBUTING.md, rejected because `.github/lychee.toml` sets `max_redirects = 0`.
- GitHub moved these docs pages; updated the links to their current URLs (verified both now return 200 directly, no redirect).

## Test plan
- [Run against branch](https://github.com/newrelic/nrdot-collector-releases/actions/runs/30667954512) shows that fix worked