### PR TITLE
fix: remove redundant system.cpu.utilization aggregation rule from host config

### DIFF
--- a/.chloggen/agarvin_remove-rule.yaml
+++ b/.chloggen/agarvin_remove-rule.yaml
@@ -5,8 +5,8 @@ change_type: bug_fix
 # Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
 issues: [646]
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove `system.cpu.utilization` aggregation rule from host config
+note: Remove `system.cpu.utilization` mean aggregation rule from host config
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: '- The `host_metrics` receiver recieved an update in `v0.157.0` which applies mean aggregation to `system.cpu.utilization` by default, rendering this rule redundant.'
+subtext: '- The `v0.157.0` update to `receiver/host_metrics` changed its default behavior to aggregate `system.cpu.utilization` by mean, rendering the removed rule redundant.'

--- a/.chloggen/agarvin_remove-rule.yaml
+++ b/.chloggen/agarvin_remove-rule.yaml
@@ -1,0 +1,12 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
+change_type: bug_fix
+# Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
+issues: [646]
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `system.cpu.utilization` aggregation rule from host config
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: '- The `host_metrics` receiver recieved an update in `v0.157.0` which applies mean aggregation to `system.cpu.utilization` by default, rendering this rule redundant.'

--- a/distributions/nrdot-collector/config.yaml
+++ b/distributions/nrdot-collector/config.yaml
@@ -68,12 +68,6 @@ processors:
   # group system.cpu metrics by cpu
   metrics_transform:
     transforms:
-      - include: system.cpu.utilization
-        action: update
-        operations:
-          - action: aggregate_labels
-            label_set: [ state ]
-            aggregation_type: mean
       - include: system.paging.operations
         action: update
         operations:


### PR DESCRIPTION
### Summary
A breaking change was pushed to the `host_metrics` receiver which changes the default behavior of `system.cpu.utilization` to aggregate by mean:
* The upstream PR author [states that the new default behavior](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49162) is to aggregate around state
* The [receiver's new unit tests](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49162/changes#diff-be258439da2511658935778657df4206334e3e2a3a0ce47b38c65bbbc35c2a01) indicate that the new default behavior aggregates on mean

This change has made the removed rule redundant.