### PR TITLE
fix: disable system.cpu.logical.count

### DIFF
--- a/.chloggen/agarvin_disable-system-cpu-logical-count.yaml
+++ b/.chloggen/agarvin_disable-system-cpu-logical-count.yaml
@@ -1,0 +1,12 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'feature', 'bug_fix', 'docs'. Inferred from conventional commit tag if PR created before `make chlog-new`.
+change_type: bug_fix
+# Mandatory. Put the PR number here. Inferred from PR number if PR created before `make chlog-new`.
+issues: [647]
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable `system.cpu.logical.count` in host config
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: '- The `v0.157.0` update to `receiver/host_metrics` enabled this metric by default. This change restores the previous behavior.'

--- a/distributions/nrdot-collector/config.yaml
+++ b/distributions/nrdot-collector/config.yaml
@@ -13,6 +13,8 @@ receivers:
     scrapers:
       cpu:
         metrics:
+          system.cpu.logical.count:
+            enabled: false
           system.cpu.time:
             enabled: false
           system.cpu.utilization:


### PR DESCRIPTION
### Summary
In v0.157.0, the `system.cpu.logical.count` metric changed to be [enabled by default](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49325). This PR disables the metric to return to the previous behavior.